### PR TITLE
Add companies house service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   global:
     - CC_TEST_REPORTER_ID=8efeb1a8373dafb8697aac6eea657464f119181de12b081941cbef146aaba209
-    - secure: "dEFcvzPrGVZ5SH0yC+paTZhYPdY229+ppy+4TCZFy4SlsxMcjtDP2431ck6EfQK95fjho0bcspkseSYBLp3Li4bpLFQF9G88aPD+KN91eZqyMK0YPSz/LtRKEaszuwDPL8k5q+kUJq45GfbNkhE2Mvze/GBcP2aHAV7Z1gnH5NoIhk89qFz2uC59Szd0h46rvOmuwAFTc1wHAn+ZG2LjPG2fs60z+w4vaFtVOb/3r6Lph9+BPswCSgP9XPVoMsT8sokf+ZN/+B8pxKhp1rwJtE/cGRa/ZmZqigEUtwJ7dJA3+QnlVLMdu0Wr+gygaMYbLuUm0QglbYTf/l5A5ofnaSBTRDDmQZocp9hitp4yaz9k4vxOYNnhvk/RMjTC44uJeYscbPdJMwF1vKH6C49Vp1Ubvwava5A8FcwWX4SrXWo5XWKc7LlYd+SpmY6MQSGdlL66BmIx5cPgvXn41IecG5sTVJW13HqF0Ai0xYxAEU+kuHVdKrFFW71fWX5cVxaHhLKhC7OlcYgagPy9gC1Tzeqyjquw6bU24nPC7C9v1DwuG8BnKFs8w3+VcK7E42E7wJsIUNasfHcLVJMKDVGHNLJkH9cWvrYugsjpkd/+lD9ky3VjrGtFw8uyFa6+XqjBxiszUwKjnb0JKmv7SQOVaGkYV3SF2tW6l9uEAjCCPLY="
+    - secure: dEFcvzPrGVZ5SH0yC+paTZhYPdY229+ppy+4TCZFy4SlsxMcjtDP2431ck6EfQK95fjho0bcspkseSYBLp3Li4bpLFQF9G88aPD+KN91eZqyMK0YPSz/LtRKEaszuwDPL8k5q+kUJq45GfbNkhE2Mvze/GBcP2aHAV7Z1gnH5NoIhk89qFz2uC59Szd0h46rvOmuwAFTc1wHAn+ZG2LjPG2fs60z+w4vaFtVOb/3r6Lph9+BPswCSgP9XPVoMsT8sokf+ZN/+B8pxKhp1rwJtE/cGRa/ZmZqigEUtwJ7dJA3+QnlVLMdu0Wr+gygaMYbLuUm0QglbYTf/l5A5ofnaSBTRDDmQZocp9hitp4yaz9k4vxOYNnhvk/RMjTC44uJeYscbPdJMwF1vKH6C49Vp1Ubvwava5A8FcwWX4SrXWo5XWKc7LlYd+SpmY6MQSGdlL66BmIx5cPgvXn41IecG5sTVJW13HqF0Ai0xYxAEU+kuHVdKrFFW71fWX5cVxaHhLKhC7OlcYgagPy9gC1Tzeqyjquw6bU24nPC7C9v1DwuG8BnKFs8w3+VcK7E42E7wJsIUNasfHcLVJMKDVGHNLJkH9cWvrYugsjpkd/+lD9ky3VjrGtFw8uyFa6+XqjBxiszUwKjnb0JKmv7SQOVaGkYV3SF2tW6l9uEAjCCPLY=
 
 language: ruby
 rvm: 2.4.2
@@ -30,5 +30,5 @@ before_script:
   # allows projects to control the version they are using (rather than getting)
   # surprise build failures.
   - bundle exec rubocop
-  after_script:
-    - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi
+after_script:
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in defra-ruby-validators.gemspec
 gemspec

--- a/lib/defra_ruby_validators/companies_house_service.rb
+++ b/lib/defra_ruby_validators/companies_house_service.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rest-client"
+
+module DefraRubyValidators
+  class CompaniesHouseService
+    def initialize(company_no)
+      @company_no = company_no
+      @url = "#{DefraRubyValidators.configuration.companies_house_host}#{@company_no}"
+      @api_key = DefraRubyValidators.configuration.companies_house_api_key
+    end
+
+    def status
+      response = RestClient::Request.execute(
+        method: :get,
+        url: @url,
+        user: @api_key,
+        password: ""
+      )
+
+      json = JSON.parse(response)
+
+      status_is_allowed?(json["company_status"]) ? :active : :inactive
+    rescue RestClient::ResourceNotFound
+      :not_found
+    end
+
+    private
+
+    def status_is_allowed?(status)
+      %w[active voluntary-arrangement].include?(status)
+    end
+  end
+end

--- a/spec/cassettes/company_no_inactive.yml
+++ b/spec/cassettes/company_no_inactive.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.companieshouse.gov.uk/company/07281919
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.3.0 x86_64) ruby/2.4.2p198
+      Host:
+      - api.companieshouse.gov.uk
+      Authorization:
+      - Basic MnZodWowb1dhYk13N2h6TnpBVWlTT2ctNktpVVRCcFhCRF83Zktibzo=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 28 Jan 2019 09:38:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '979'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-RateLimit-Query, origin, content-type, content-length, user-agent, host,
+        accept, authorization
+      Access-Control-Expose-Headers:
+      - Location,www-authenticate,cache-control,pragma,content-type,expires,last-modified
+      - X-RateLimit-Window, X-RateLimit-Limit, X-RateLimit-Remain, X-RateLimit-Reset,
+        Location, www-authenticate, cache-control, pragma, content-type, expires,
+        last-modified
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '600'
+      X-Ratelimit-Remain:
+      - '596'
+      X-Ratelimit-Reset:
+      - '1548668445'
+      X-Ratelimit-Window:
+      - 5m
+      Server:
+      - CompaniesHouse
+    body:
+      encoding: UTF-8
+      string: '{"sic_codes":["82990"],"company_number":"07281919","has_been_liquidated":false,"accounts":{"last_accounts":{"made_up_to":"2013-06-30","type":"total-exemption-small"},"accounting_reference_date":{"day":"30","month":"06"}},"last_full_members_list_date":"2014-06-11","status":"active","type":"ltd","date_of_creation":"2010-06-11","registered_office_address":{"postal_code":"HA8
+        7EJ","locality":"Edgware","region":"Middlesex","address_line_1":"8th Floor
+        Elizabeth House","address_line_2":"54-58 High Street"},"undeliverable_registered_office_address":false,"company_name":"DIRECT
+        SKIPS UK LTD","annual_return":{"last_made_up_to":"2014-06-11"},"jurisdiction":"england-wales","etag":"1cdef5bc2a020b3e9003b086033b64b78bcb28f6","company_status":"dissolved","has_insolvency_history":false,"has_charges":false,"links":{"self":"/company/07281919","filing_history":"/company/07281919/filing-history","officers":"/company/07281919/officers"},"date_of_cessation":"2016-01-05","can_file":false}'
+    http_version: 
+  recorded_at: Mon, 28 Jan 2019 09:38:50 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/company_no_not_found.yml
+++ b/spec/cassettes/company_no_not_found.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.companieshouse.gov.uk/company/99999999
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.3.0 x86_64) ruby/2.4.2p198
+      Host:
+      - api.companieshouse.gov.uk
+      Authorization:
+      - Basic MnZodWowb1dhYk13N2h6TnpBVWlTT2ctNktpVVRCcFhCRF83Zktibzo=
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Mon, 28 Jan 2019 09:38:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '70'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-RateLimit-Query, origin, content-type, content-length, user-agent, host,
+        accept, authorization
+      Access-Control-Expose-Headers:
+      - Location,www-authenticate,cache-control,pragma,content-type,expires,last-modified
+      - X-RateLimit-Window, X-RateLimit-Limit, X-RateLimit-Remain, X-RateLimit-Reset,
+        Location, www-authenticate, cache-control, pragma, content-type, expires,
+        last-modified
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '600'
+      X-Ratelimit-Remain:
+      - '597'
+      X-Ratelimit-Reset:
+      - '1548668445'
+      X-Ratelimit-Window:
+      - 5m
+      Server:
+      - CompaniesHouse
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"error":"company-profile-not-found","type":"ch:service"}]}'
+    http_version: 
+  recorded_at: Mon, 28 Jan 2019 09:38:50 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/company_no_valid.yml
+++ b/spec/cassettes/company_no_valid.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.companieshouse.gov.uk/company/09360070
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.3.0 x86_64) ruby/2.4.2p198
+      Host:
+      - api.companieshouse.gov.uk
+      Authorization:
+      - Basic MnZodWowb1dhYk13N2h6TnpBVWlTT2ctNktpVVRCcFhCRF83Zktibzo=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 27 Jan 2019 23:57:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1178'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-RateLimit-Query, origin, content-type, content-length, user-agent, host,
+        accept, authorization
+      Access-Control-Expose-Headers:
+      - Location,www-authenticate,cache-control,pragma,content-type,expires,last-modified
+      - X-RateLimit-Window, X-RateLimit-Limit, X-RateLimit-Remain, X-RateLimit-Reset,
+        Location, www-authenticate, cache-control, pragma, content-type, expires,
+        last-modified
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      X-Ratelimit-Limit:
+      - '600'
+      X-Ratelimit-Remain:
+      - '598'
+      X-Ratelimit-Reset:
+      - '1548633621'
+      X-Ratelimit-Window:
+      - 5m
+      Server:
+      - CompaniesHouse
+    body:
+      encoding: UTF-8
+      string: '{"type":"ltd","company_name":"0800 WASTE LTD.","has_insolvency_history":false,"accounts":{"next_due":"2019-09-30","next_made_up_to":"2018-12-31","next_accounts":{"overdue":false,"period_start_on":"2018-01-01","due_on":"2019-09-30","period_end_on":"2018-12-31"},"accounting_reference_date":{"month":"12","day":"31"},"last_accounts":{"period_end_on":"2017-12-31","period_start_on":"2017-01-01","made_up_to":"2017-12-31"},"overdue":false},"undeliverable_registered_office_address":false,"etag":"0ec9d00cab0ffee2ef1f5d59f4f714fa5b1618f5","company_number":"09360070","registered_office_address":{"postal_code":"SM3
+        9ND","locality":"Sutton","region":"Surrey","address_line_1":"21 Haslam Avenue"},"jurisdiction":"england-wales","date_of_creation":"2014-12-18","company_status":"active","has_charges":false,"sic_codes":["38110"],"last_full_members_list_date":"2015-12-18","confirmation_statement":{"overdue":false,"next_made_up_to":"2020-01-23","last_made_up_to":"2019-01-23","next_due":"2020-02-06"},"links":{"self":"/company/09360070","filing_history":"/company/09360070/filing-history","officers":"/company/09360070/officers"},"registered_office_is_in_dispute":false,"can_file":true}'
+    http_version: 
+  recorded_at: Sun, 27 Jan 2019 23:57:58 GMT
+recorded_with: VCR 4.0.0

--- a/spec/defra_ruby_validators/companies_house_service_spec.rb
+++ b/spec/defra_ruby_validators/companies_house_service_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module DefraRubyValidators
+  RSpec.describe CompaniesHouseService do
+    let(:companies_house_service) { CompaniesHouseService.new("09360070") }
+
+    context "when a company_no is for an active company" do
+      it "returns :active" do
+        VCR.use_cassette("company_no_valid") do
+          expect(companies_house_service.status).to eq(:active)
+        end
+      end
+    end
+
+    context "when a company_no is not found" do
+      let(:companies_house_service) { CompaniesHouseService.new("99999999") }
+
+      it "returns :not_found" do
+        VCR.use_cassette("company_no_not_found") do
+          expect(companies_house_service.status).to eq(:not_found)
+        end
+      end
+    end
+
+    context "when a company_no is inactive" do
+      let(:companies_house_service) { CompaniesHouseService.new("07281919") }
+
+      it "returns :inactive" do
+        VCR.use_cassette("company_no_inactive") do
+          expect(companies_house_service.status).to eq(:inactive)
+        end
+      end
+    end
+
+    context "when the request times out" do
+      it "raises an exception" do
+        VCR.turned_off do
+          host = "https://api.companieshouse.gov.uk/"
+          stub_request(:any, /.*#{host}.*/).to_timeout
+          expect { companies_house_service.status }.to raise_error(StandardError)
+        end
+      end
+    end
+
+    context "when the request returns an error" do
+      it "raises an exception" do
+        VCR.turned_off do
+          host = "https://api.companieshouse.gov.uk/"
+          stub_request(:any, /.*#{host}.*/).to_raise(SocketError)
+          expect { companies_house_service.status }.to raise_error(StandardError)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Prior to implementing a validator for companies house number this changes adds the companies house service to the project.

The service will be used to make calls to companies house to validate the number provided e.g. is it recognised and does it belong to an active company.

The code for the service has come from [WCR renewals](https://github.com/DEFRA/waste-carriers-renewals) and [WEX engine](https://github.com/DEFRA/waste-exemptions-engine), where it was essentially duplicated.

This change is the first step in moving the companies house number validation to a shared gem and thus removing the duplication.