### PR TITLE
Fix configuration ready for hosting in engine

### DIFF
--- a/lib/defra_ruby_validators.rb
+++ b/lib/defra_ruby_validators.rb
@@ -1,29 +1,14 @@
 # frozen_string_literal: true
 
-require "defra_ruby_validators/version"
-
-require "defra_ruby_validators/companies_house_service"
+require "defra_ruby_validators/engine"
 
 module DefraRubyValidators
-
-  # Enable the ability to configure the gem from its host app, rather than
-  # reading directly from env vars.
-  # https://robots.thoughtbot.com/mygem-configure-block
-  class << self
-    attr_accessor :configuration
-  end
-
-  def self.configure
-    self.configuration ||= Configuration.new
-    yield(configuration)
-  end
-
-  class Configuration
-    attr_accessor :companies_house_host, :companies_house_api_key
-
-    def initialize
-      @companies_house_host = "https://api.companieshouse.gov.uk/company/"
-      @companies_house_api_key = nil
-    end
-  end
+  # See lib/defra_ruby_validators/validators.rb for the main content.
+  # We have this file which just require's engine.rb to support using the gem
+  # in a rails project.
+  # For our test suite, we just want the typical listing of `require "filex"`,
+  # as the engine references using Rails.
+  # We also have the gem setup to support being configured from the host app.
+  # This is all done in `validators.rb`, which is picked up by `engine.rb` as
+  # well.
 end

--- a/lib/defra_ruby_validators/engine.rb
+++ b/lib/defra_ruby_validators/engine.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "defra_ruby_validators/validators"
+
+module DefraRubyValidators
+  # Engine used to load in the custom validations
+  class Engine < ::Rails::Engine
+    isolate_namespace DefraRubyValidators
+
+    # Add a load path for this specific Engine
+    config.autoload_paths += Dir[File.join(config.root, "lib", "**")]
+
+    # Load I18n translation files from engine before loading ones from the host app
+    # This means values in the host app can override those in the engine
+    config.before_initialize do
+      engine_locales = Dir["#{config.root}/config/locales/**/*.yml"]
+      config.i18n.load_path = engine_locales + config.i18n.load_path
+    end
+  end
+end

--- a/lib/defra_ruby_validators/validators.rb
+++ b/lib/defra_ruby_validators/validators.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "active_model"
+require "defra_ruby_validators/version"
+require "defra_ruby_validators/companies_house_service"
+
+module DefraRubyValidators
+  # Enable the ability to configure the gem from its host app, rather than
+  # reading directly from env vars. Derived from
+  # https://robots.thoughtbot.com/mygem-configure-block
+  class << self
+    attr_writer :configuration
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+  end
+
+  def self.configure
+    yield(configuration)
+  end
+
+  class Configuration
+    attr_accessor :companies_house_host, :companies_house_api_key
+
+    def initialize
+      @companies_house_host = "https://api.companieshouse.gov.uk/company/"
+      @companies_house_api_key = nil
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,24 +1,22 @@
 # frozen_string_literal: true
 
+require "bundler/setup"
+
 # Test coverage report
 require "simplecov"
 SimpleCov.start
 
-require "bundler/setup"
+# Support debugging in the tests
 require "byebug"
 # Load env vars from a text file
 require "dotenv/load"
-# Stubbing HTTP requests
-require "webmock/rspec"
-# Auto generate fake responses for web-requests
-require "vcr"
+# Need to require our actual code files
+require "defra_ruby_validators/validators"
 
 # The following line is provided for convenience purposes. It has the downside
 # of increasing the boot-up time by auto-requiring all files in the support
 # directory. However in a small gem like this the increase should be neglible
 Dir[File.join(__dir__, "support", "**", "*.rb")].each { |f| require f }
-
-require "defra_ruby_validators"
 
 RSpec.configure do |config|
   # Allows RSpec to persist some state between runs in order to support
@@ -31,11 +29,5 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
-  end
-
-  config.before(:all) do
-    DefraRubyValidators.configure do |configuration|
-      configuration.companies_house_api_key = ENV["COMPANIES_HOUSE_API_KEY"]
-    end
   end
 end

--- a/spec/support/defra_ruby_validators.rb
+++ b/spec/support/defra_ruby_validators.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+DefraRubyValidators.configure do |configuration|
+  configuration.companies_house_api_key = ENV["COMPANIES_HOUSE_API_KEY"]
+end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+# Stubbing HTTP requests
+require "webmock/rspec"
+# Auto generate fake responses for web-requests
+require "vcr"
+
 VCR.configure do |c|
   c.cassette_library_dir = "spec/cassettes"
   c.hook_into :webmock


### PR DESCRIPTION
The intention of this gem is that it will actually be used in an engine rather than directly in the host app.

After some initial tests we found that the current setup prevented this. These changes resolve the issues, notably

- Add the missing require link between `lib/defra_ruby_validators/engine.rb` and `lib/defra_ruby_validators/validators.rb`
- Fix where the config should sit (`lib/defra_ruby_validators/validators.rb`)
- Make it so you do not have to call `DefraRubyValidators.configure` before calling `DefraRubyValidators.configuration` to avoid an error
- Move VCR setup in rspec to its own support file
- Move DefraRubyValidators setup in rspec to its own support file

These changes mean the gem can be mounted within another engine, and the rspec setup more closely matches initializing the gem in a host.