### PR TITLE
Add companies house number validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Package of validations commonly used in Defra Rails based digital services.
 Add this line to your application's Gemfile
 
 ```ruby
-gem 'defra_ruby_validators'
+gem "defra_ruby_validators"
 ```
 
 And then update your dependencies by calling
@@ -34,23 +34,34 @@ This validator checks the company registration number provided. Specifically it 
 - SC534714
 - IP00141R
 
-If the format is valid, it then makes a call to companies house to validate that the number
+If the format is valid, it then makes a call to Companies House to validate that the number
 
 - is recognised
 - belongs to an 'active' company
 
 A company can be in various states for example liquidation, which means for the purposes of Defra its not a valid entity. So we check the status along with the number as part of the validation.
 
-Add it to your model using
+Add it to your model or form object using
 
 ```ruby
-validates :number, "defra_ruby_validators/companies_house_number": true
+validates :company_no, "defra_ruby_validators/companies_house_number": true
 ```
 
-A locale hint is available for your views, that details the restrictions, e.g
+A locale hint plus help text is also available for your views, that details what a registration number is and the restrictions, e.g
 
-```ruby
-  <span class="form-hint"><%= t('defra_validators.errors.companies_house_number.hint') %></span>
+```erb
+  <span class="form-hint"><%= t("defra_validators.companies_house_number.hint") %></span>
+
+  <div class="form-group">
+    <details>
+      <summary>
+        <span class="summary"><%= t("defra_validators.companies_house_number.help.heading") %></span>
+      </summary>
+      <div class="panel panel-border-narrow">
+        <p><%= t("defra_validators.companies_house_number.help.#{@form.business_type}") %></p>
+      </div>
+    </details>
+  </div>
 ```
 
 ## Contributing to this project

--- a/config/locales/defra_ruby_validators/companies_house_number/en.yml
+++ b/config/locales/defra_ruby_validators/companies_house_number/en.yml
@@ -1,0 +1,14 @@
+en:
+  defra_ruby_validators:
+    companies_house_number:
+      hint: An 8 digit number, or 2 letters followed by a 6 digit number, or 2 letters followed by 5 digits and another letter
+      help:
+        heading: What's a registration number?
+        limitedCompany: This is issued when the company is registered, and can be found on your Certificate of Incorporation and any paperwork from Companies House.
+        limitedLiabilityPartnership: This is issued when the limited liability partnership is registered, and can be found on your Certificate of Incorporation and any paperwork from Companies House.
+      errors:
+        blank: Enter a company registration number
+        invalid: "Enter a valid number - it should have 8 digits, or 2 letters followed by 6 digits, or 2 letters followed by 5 digits and another letter. If your number has only 7 digits, enter it with a zero at the start."
+        not_found: Companies House couldn't find a company with this number
+        inactive: Your company must be registered as an active company
+        error: There was an error connecting with Companies House. Hopefully this is a one off and will work if you try again.

--- a/defra-ruby-validators.gemspec
+++ b/defra-ruby-validators.gemspec
@@ -46,6 +46,8 @@ Gem::Specification.new do |spec|
   # ~/.bash_profile (or equivalent)
   # https://github.com/skywinder/github-changelog-generator#github-token
   spec.add_development_dependency "github_changelog_generator"
+  # Allows us to check in our tests that the right message is being picked up
+  spec.add_development_dependency "i18n"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop"

--- a/lib/defra_ruby_validators/companies_house_number_validator.rb
+++ b/lib/defra_ruby_validators/companies_house_number_validator.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module DefraRubyValidators
+  class CompaniesHouseNumberValidator < ActiveModel::EachValidator
+
+    # Examples we need to validate are
+    # 10997904, 09764739
+    # SC534714, CE000958
+    # IP00141R, IP27702R, SP02252R
+    # https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/426891/uniformResourceIdentifiersCustomerGuide.pdf
+    VALID_COMPANIES_HOUSE_REGISTRATION_NUMBER_REGEX = Regexp.new(
+      /\A(\d{8,8}$)|([a-zA-Z]{2}\d{6}$)|([a-zA-Z]{2}\d{5}[a-zA-Z]{1}$)\z/i
+    ).freeze
+
+    def validate_each(record, attribute, value)
+      return false unless value_is_present?(record, attribute, value)
+      return false unless format_is_valid?(record, attribute, value)
+
+      validate_with_companies_house(record, attribute, value)
+    end
+
+    private
+
+    def value_is_present?(record, attribute, value)
+      return true if value.present?
+
+      record.errors[attribute] << error_message("blank")
+      false
+    end
+
+    def format_is_valid?(record, attribute, value)
+      return true if value.match?(VALID_COMPANIES_HOUSE_REGISTRATION_NUMBER_REGEX)
+
+      record.errors[attribute] << error_message("invalid")
+      false
+    end
+
+    def validate_with_companies_house(record, attribute, value)
+      case CompaniesHouseService.new(value).status
+      when :active
+        true
+      when :inactive
+        record.errors[attribute] << error_message("inactive")
+      when :not_found
+        record.errors[attribute] << error_message("not_found")
+      end
+    rescue StandardError
+      record.errors[attribute] << error_message("error")
+    end
+
+    def error_message(error)
+      I18n.t("defra_ruby_validators.companies_house_number.errors.#{error}")
+    end
+
+  end
+end

--- a/lib/defra_ruby_validators/validators.rb
+++ b/lib/defra_ruby_validators/validators.rb
@@ -4,6 +4,8 @@ require "active_model"
 require "defra_ruby_validators/version"
 require "defra_ruby_validators/companies_house_service"
 
+require "defra_ruby_validators/companies_house_number_validator"
+
 module DefraRubyValidators
   # Enable the ability to configure the gem from its host app, rather than
   # reading directly from env vars. Derived from

--- a/spec/defra_ruby_validators/companies_house_number_validator_spec.rb
+++ b/spec/defra_ruby_validators/companies_house_number_validator_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module DefraRubyValidators
+  RSpec.describe CompaniesHouseNumberValidator do
+    context "when given a valid company number" do
+      before do
+        allow_any_instance_of(CompaniesHouseService).to receive(:status).and_return(:active)
+      end
+
+      %w[10997904 09764739 SC534714 IP00141R].each do |company_no|
+        context "like #{company_no}" do
+          it "confirms the number is valid" do
+            expect(DummyCompaniesHouseNumber.new(company_no)).to be_valid
+          end
+        end
+      end
+    end
+
+    context "when given an invalid company number" do
+      context "because it is blank" do
+        subject { DummyCompaniesHouseNumber.new("") }
+
+        it "confirms the number is not valid" do
+          expect(subject).to_not be_valid
+        end
+        it "adds an error to the subject's errors collection" do
+          subject.valid?
+          expect(subject.errors.count).to eq(1)
+        end
+        it "adds an error with the correct message" do
+          subject.valid?
+          expect(subject.errors[:company_no][0]).to eq(I18n.t("defra_ruby_validators.companies_house_number.errors.blank"))
+        end
+      end
+
+      context "because the format is wrong" do
+        subject { DummyCompaniesHouseNumber.new("foobar42") }
+
+        it "confirms the number is not valid" do
+          expect(subject).to_not be_valid
+        end
+        it "adds an error to the subject's errors collection" do
+          subject.valid?
+          expect(subject.errors.count).to eq(1)
+        end
+        it "adds an error with the correct message" do
+          subject.valid?
+          expect(subject.errors[:company_no][0]).to eq(I18n.t("defra_ruby_validators.companies_house_number.errors.invalid"))
+        end
+      end
+
+      context "because it's not found on companies house" do
+        before do
+          allow_any_instance_of(CompaniesHouseService).to receive(:status).and_return(:not_found)
+        end
+
+        subject { DummyCompaniesHouseNumber.new("99999999") }
+
+        it "confirms the number is not valid" do
+          expect(subject).to_not be_valid
+        end
+        it "adds an error to the subject's errors collection" do
+          subject.valid?
+          expect(subject.errors.count).to eq(1)
+        end
+        it "adds an error with the correct message" do
+          subject.valid?
+          expect(subject.errors[:company_no][0]).to eq(I18n.t("defra_ruby_validators.companies_house_number.errors.not_found"))
+        end
+      end
+
+      context "because it's not 'active' on companies house" do
+        before do
+          allow_any_instance_of(CompaniesHouseService).to receive(:status).and_return(:inactive)
+        end
+
+        subject { DummyCompaniesHouseNumber.new("07281919") }
+
+        it "confirms the number is not valid" do
+          expect(subject).to_not be_valid
+        end
+        it "adds an error to the subject's errors collection" do
+          subject.valid?
+          expect(subject.errors.count).to eq(1)
+        end
+        it "adds an error with the correct message" do
+          subject.valid?
+          expect(subject.errors[:company_no][0]).to eq(I18n.t("defra_ruby_validators.companies_house_number.errors.inactive"))
+        end
+      end
+    end
+
+    context "when there is an error connecting with companies house" do
+      before do
+        allow_any_instance_of(CompaniesHouseService).to receive(:status).and_raise(StandardError)
+      end
+
+      subject { DummyCompaniesHouseNumber.new("10997904") }
+
+      it "confirms the number is not valid" do
+        expect(subject).to_not be_valid
+      end
+      it "adds an error to the subject's errors collection" do
+        subject.valid?
+        expect(subject.errors.count).to eq(1)
+      end
+      it "adds an error with the correct message" do
+        subject.valid?
+        expect(subject.errors[:company_no][0]).to eq(I18n.t("defra_ruby_validators.companies_house_number.errors.error"))
+      end
+    end
+
+    class DummyCompaniesHouseNumber
+      include ActiveModel::Model
+
+      attr_accessor :company_no
+
+      def initialize(company_no)
+        @company_no = company_no
+      end
+
+      validates :company_no, "defra_ruby_validators/companies_house_number": true
+    end
+  end
+end

--- a/spec/defra_ruby_validators/companies_house_service_spec.rb
+++ b/spec/defra_ruby_validators/companies_house_service_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 module DefraRubyValidators
   RSpec.describe CompaniesHouseService do
     let(:companies_house_service) { CompaniesHouseService.new("09360070") }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 
 require "bundler/setup"
 
-# Test coverage report
+# Test coverage reporting
 require "simplecov"
 SimpleCov.start
 

--- a/spec/support/i18n.rb
+++ b/spec/support/i18n.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Support using the locale files within our tests (else we'd rely on loading the
+# gem in a rails app to confirm these are being pulled through correctly.)
+require "i18n"
+
+I18n.load_path << Dir[File.expand_path("config/locales") + "/**/*.yml"]
+I18n.default_locale = :en


### PR DESCRIPTION
This is the first actual validator we are adding to the gem, and it covers validating a company registration number.

Limited companies (LTD) and Limited Liability Partnerships (LLP) have to be registered with [Companies House](https://beta.companieshouse.gov.uk) so as part of our services we like to validate any number submitted.

The first step is ensuring a value has been provided. We then check the format is valid before making a call to Companies House to confirm its recognised and the company is 'active'.

We already added the service object which handles talking to companies house in a previous commit. This change adds the validator itself which makes use of `CompaniesHouseService`.

This change also incorporates a few other things

- adding [I18n](https://github.com/ruby-i18n/i18n) as a dev dependency to ensure translations work when running tests, so we can confirm the right message is being pulled through
- some housekeeping in `spec_helper.rb`, including removing unnecessary `require "spec_helper" calls in the tests (this is handled by `.rspec`)