### PR TITLE
Fix missing translations

### DIFF
--- a/defra_ruby_validators.gemspec
+++ b/defra_ruby_validators.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "Defra ruby on rails validations"
   spec.description   = "Package of validations commonly used in Defra Rails based digital services"
 
-  spec.files = Dir["{bin,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
+  spec.files = Dir["{bin,config,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
   spec.test_files = Dir["spec/**/*"]
 
   spec.require_paths = ["lib"]

--- a/lib/defra_ruby_validators/version.rb
+++ b/lib/defra_ruby_validators/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DefraRubyValidators
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
Spotted that the way we were building the gem as set in the gemspec meant that the translations in `config/` were not being included.

Oops!

This change fixes that, and bumps the version number ready for a new release.