### PR TITLE
Add a true/false validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ A locale hint plus help text is also available for your views, that details what
   </div>
 ```
 
+### True / False
+
+This validator checks the value provided is either 'true' or 'false'. Note it expects a string and not a boolean value.
+
+Add it to your model or form object using
+
+```ruby
+validates :value, "defra_ruby_validators/true_false": true
+```
+
 ## Contributing to this project
 
 If you have an idea you'd like to contribute please log an issue.

--- a/config/locales/defra_ruby_validators/true_false/en.yml
+++ b/config/locales/defra_ruby_validators/true_false/en.yml
@@ -1,0 +1,6 @@
+en:
+  defra_ruby_validators:
+    true_false:
+      errors:
+        blank: You must answer this question
+        invalid: You must answer true or false for this question

--- a/lib/defra_ruby_validators/true_false_validator.rb
+++ b/lib/defra_ruby_validators/true_false_validator.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module DefraRubyValidators
+  class TrueFalseValidator < ActiveModel::EachValidator
+
+    def validate_each(record, attribute, value)
+      return false unless value_is_present?(record, attribute, value)
+      return false unless value_is_valid?(record, attribute, value)
+
+      true
+    end
+
+    private
+
+    def value_is_present?(record, attribute, value)
+      return true if value.present?
+
+      record.errors[attribute] << error_message("blank")
+      false
+    end
+
+    def value_is_valid?(record, attribute, value)
+      valid_values = %w[true false]
+      return true if valid_values.include?(value)
+
+      record.errors[attribute] << error_message("invalid")
+      false
+    end
+
+    def error_message(error)
+      I18n.t("defra_ruby_validators.true_false.errors.#{error}")
+    end
+  end
+end

--- a/lib/defra_ruby_validators/validators.rb
+++ b/lib/defra_ruby_validators/validators.rb
@@ -5,6 +5,7 @@ require "defra_ruby_validators/version"
 require "defra_ruby_validators/companies_house_service"
 
 require "defra_ruby_validators/companies_house_number_validator"
+require "defra_ruby_validators/true_false_validator"
 
 module DefraRubyValidators
   # Enable the ability to configure the gem from its host app, rather than

--- a/lib/defra_ruby_validators/version.rb
+++ b/lib/defra_ruby_validators/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DefraRubyValidators
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end

--- a/spec/cassettes/company_no_inactive.yml
+++ b/spec/cassettes/company_no_inactive.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 28 Jan 2019 09:38:50 GMT
+      - Tue, 12 Feb 2019 09:50:05 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -49,9 +49,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '600'
       X-Ratelimit-Remain:
-      - '596'
+      - '597'
       X-Ratelimit-Reset:
-      - '1548668445'
+      - '1549965305'
       X-Ratelimit-Window:
       - 5m
       Server:
@@ -63,5 +63,5 @@ http_interactions:
         Elizabeth House","address_line_2":"54-58 High Street"},"undeliverable_registered_office_address":false,"company_name":"DIRECT
         SKIPS UK LTD","annual_return":{"last_made_up_to":"2014-06-11"},"jurisdiction":"england-wales","etag":"1cdef5bc2a020b3e9003b086033b64b78bcb28f6","company_status":"dissolved","has_insolvency_history":false,"has_charges":false,"links":{"self":"/company/07281919","filing_history":"/company/07281919/filing-history","officers":"/company/07281919/officers"},"date_of_cessation":"2016-01-05","can_file":false}'
     http_version: 
-  recorded_at: Mon, 28 Jan 2019 09:38:50 GMT
+  recorded_at: Tue, 12 Feb 2019 09:50:05 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/company_no_not_found.yml
+++ b/spec/cassettes/company_no_not_found.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Mon, 28 Jan 2019 09:38:50 GMT
+      - Tue, 12 Feb 2019 09:50:05 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -49,16 +49,16 @@ http_interactions:
       X-Ratelimit-Limit:
       - '600'
       X-Ratelimit-Remain:
-      - '597'
+      - '598'
       X-Ratelimit-Reset:
-      - '1548668445'
+      - '1549965305'
       X-Ratelimit-Window:
       - 5m
       Server:
       - CompaniesHouse
     body:
       encoding: UTF-8
-      string: '{"errors":[{"error":"company-profile-not-found","type":"ch:service"}]}'
+      string: '{"errors":[{"type":"ch:service","error":"company-profile-not-found"}]}'
     http_version: 
-  recorded_at: Mon, 28 Jan 2019 09:38:50 GMT
+  recorded_at: Tue, 12 Feb 2019 09:50:05 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/company_no_valid.yml
+++ b/spec/cassettes/company_no_valid.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 27 Jan 2019 23:57:58 GMT
+      - Tue, 12 Feb 2019 09:50:05 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -49,9 +49,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '600'
       X-Ratelimit-Remain:
-      - '598'
+      - '599'
       X-Ratelimit-Reset:
-      - '1548633621'
+      - '1549965305'
       X-Ratelimit-Window:
       - 5m
       Server:
@@ -61,5 +61,5 @@ http_interactions:
       string: '{"type":"ltd","company_name":"0800 WASTE LTD.","has_insolvency_history":false,"accounts":{"next_due":"2019-09-30","next_made_up_to":"2018-12-31","next_accounts":{"overdue":false,"period_start_on":"2018-01-01","due_on":"2019-09-30","period_end_on":"2018-12-31"},"accounting_reference_date":{"month":"12","day":"31"},"last_accounts":{"period_end_on":"2017-12-31","period_start_on":"2017-01-01","made_up_to":"2017-12-31"},"overdue":false},"undeliverable_registered_office_address":false,"etag":"0ec9d00cab0ffee2ef1f5d59f4f714fa5b1618f5","company_number":"09360070","registered_office_address":{"postal_code":"SM3
         9ND","locality":"Sutton","region":"Surrey","address_line_1":"21 Haslam Avenue"},"jurisdiction":"england-wales","date_of_creation":"2014-12-18","company_status":"active","has_charges":false,"sic_codes":["38110"],"last_full_members_list_date":"2015-12-18","confirmation_statement":{"overdue":false,"next_made_up_to":"2020-01-23","last_made_up_to":"2019-01-23","next_due":"2020-02-06"},"links":{"self":"/company/09360070","filing_history":"/company/09360070/filing-history","officers":"/company/09360070/officers"},"registered_office_is_in_dispute":false,"can_file":true}'
     http_version: 
-  recorded_at: Sun, 27 Jan 2019 23:57:58 GMT
+  recorded_at: Tue, 12 Feb 2019 09:50:05 GMT
 recorded_with: VCR 4.0.0

--- a/spec/defra_ruby_validators/true_false_validator_spec.rb
+++ b/spec/defra_ruby_validators/true_false_validator_spec.rb
@@ -1,18 +1,29 @@
 # frozen_string_literal: true
 
+module Test
+  TrueFalseValidatable = Struct.new(:value) do
+    include ActiveModel::Validations
+
+    validates :value, "defra_ruby_validators/true_false": true
+  end
+end
+
 module DefraRubyValidators
-  RSpec.describe TrueFalseValidator do
+  RSpec.describe TrueFalseValidator, type: :model do
+
     %w[true false].each do |value|
       context "when given the valid value '#{value}'" do
+        subject { Test::TrueFalseValidatable.new(value) }
+
         it "confirms the value is valid" do
-          expect(DummyTrueFalse.new(value)).to be_valid
+          expect(subject).to be_valid
         end
       end
     end
 
     context "when given an invalid value" do
       context "because it is blank" do
-        subject { DummyTrueFalse.new("") }
+        subject { Test::TrueFalseValidatable.new("") }
 
         it "confirms the value is not valid" do
           expect(subject).to_not be_valid
@@ -26,34 +37,22 @@ module DefraRubyValidators
           expect(subject.errors[:value][0]).to eq(I18n.t("defra_ruby_validators.true_false.errors.blank"))
         end
       end
-    end
 
-    context "because the value is not recognised" do
-      subject { DummyTrueFalse.new("foobar") }
+      context "because the value is not recognised" do
+        subject { Test::TrueFalseValidatable.new("foobar") }
 
-      it "confirms the value is not valid" do
-        expect(subject).to_not be_valid
+        it "confirms the value is not valid" do
+          expect(subject).to_not be_valid
+        end
+        it "adds an error to the subject's errors collection" do
+          subject.valid?
+          expect(subject.errors.count).to eq(1)
+        end
+        it "adds an error with the correct message" do
+          subject.valid?
+          expect(subject.errors[:value][0]).to eq(I18n.t("defra_ruby_validators.true_false.errors.invalid"))
+        end
       end
-      it "adds an error to the subject's errors collection" do
-        subject.valid?
-        expect(subject.errors.count).to eq(1)
-      end
-      it "adds an error with the correct message" do
-        subject.valid?
-        expect(subject.errors[:value][0]).to eq(I18n.t("defra_ruby_validators.true_false.errors.invalid"))
-      end
-    end
-
-    class DummyTrueFalse
-      include ActiveModel::Model
-
-      attr_accessor :value
-
-      def initialize(value)
-        @value = value
-      end
-
-      validates :value, "defra_ruby_validators/true_false": true
     end
   end
 end

--- a/spec/defra_ruby_validators/true_false_validator_spec.rb
+++ b/spec/defra_ruby_validators/true_false_validator_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module DefraRubyValidators
+  RSpec.describe TrueFalseValidator do
+    %w[true false].each do |value|
+      context "when given the valid value '#{value}'" do
+        it "confirms the value is valid" do
+          expect(DummyTrueFalse.new(value)).to be_valid
+        end
+      end
+    end
+
+    context "when given an invalid value" do
+      context "because it is blank" do
+        subject { DummyTrueFalse.new("") }
+
+        it "confirms the value is not valid" do
+          expect(subject).to_not be_valid
+        end
+        it "adds an error to the subject's errors collection" do
+          subject.valid?
+          expect(subject.errors.count).to eq(1)
+        end
+        it "adds an error with the correct message" do
+          subject.valid?
+          expect(subject.errors[:value][0]).to eq(I18n.t("defra_ruby_validators.true_false.errors.blank"))
+        end
+      end
+    end
+
+    context "because the value is not recognised" do
+      subject { DummyTrueFalse.new("foobar") }
+
+      it "confirms the value is not valid" do
+        expect(subject).to_not be_valid
+      end
+      it "adds an error to the subject's errors collection" do
+        subject.valid?
+        expect(subject.errors.count).to eq(1)
+      end
+      it "adds an error with the correct message" do
+        subject.valid?
+        expect(subject.errors[:value][0]).to eq(I18n.t("defra_ruby_validators.true_false.errors.invalid"))
+      end
+    end
+
+    class DummyTrueFalse
+      include ActiveModel::Model
+
+      attr_accessor :value
+
+      def initialize(value)
+        @value = value
+      end
+
+      validates :value, "defra_ruby_validators/true_false": true
+    end
+  end
+end


### PR DESCRIPTION
This adds a new validator to the gem, specifically for checking if a value is either 'true' or 'false.

In the Waste Exemptions service there are a couple of pages where we want the user to provide a simple **yes/no** answer to a question.

Because of this we hold the values as booleans in the database, however this gets translated in the view as setting the radio button values to 'true' and 'false'.

When the answer is submitted is when the validator is expected to be used hence it validates whether the submitted value is either 'true' or 'false'.

---

WIP