### PR TITLE
Fix references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,21 +45,21 @@ A company can be in various states for example liquidation, which means for the 
 Add it to your model or form object using
 
 ```ruby
-validates :company_no, "defra_ruby_validators/companies_house_number": true
+validates :company_no, "defra_ruby/validators/companies_house_number": true
 ```
 
 A locale hint plus help text is also available for your views, that details what a registration number is and the restrictions, e.g
 
 ```erb
-  <span class="form-hint"><%= t("defra_validators.companies_house_number.hint") %></span>
+  <span class="form-hint"><%= t("defra_ruby.validators.companies_house_number.hint") %></span>
 
   <div class="form-group">
     <details>
       <summary>
-        <span class="summary"><%= t("defra_validators.companies_house_number.help.heading") %></span>
+        <span class="summary"><%= t("defra_ruby.validators.companies_house_number.help.heading") %></span>
       </summary>
       <div class="panel panel-border-narrow">
-        <p><%= t("defra_validators.companies_house_number.help.#{@form.business_type}") %></p>
+        <p><%= t("defra_ruby.validators.companies_house_number.help.#{@form.business_type}") %></p>
       </div>
     </details>
   </div>


### PR DESCRIPTION
We omitted updating the references in the README following the namespace refactor in PR #6. This change rectifies that omission.