### PR TITLE
Make rspec support consistent

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,1 @@
---format documentation
---color
 --require spec_helper

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,9 +6,6 @@ require "bundler/setup"
 # This is as per its docs https://github.com/colszowka/simplecov#getting-started
 require "./spec/support/simplecov"
 
-# Load env vars from a text file
-require "dotenv/load"
-
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,8 +6,6 @@ require "bundler/setup"
 # This is as per its docs https://github.com/colszowka/simplecov#getting-started
 require "./spec/support/simplecov"
 
-# Support debugging in the tests
-require "byebug"
 # Load env vars from a text file
 require "dotenv/load"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,12 +10,6 @@ require "./spec/support/simplecov"
 require "byebug"
 # Load env vars from a text file
 require "dotenv/load"
-# Need to require our actual code files. We don't just require everything in
-# lib/defra_ruby because it contains the engine file which has a dependency on
-# rails. We don't have that as a dependency of this project because it is
-# a given this will be used in a rails project. So instead we require the
-# validators file directly to load the content covered by our tests.
-require "defra_ruby/validators"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,15 +20,64 @@ support_files = Dir["./spec/support/**/*.rb"].reject { |file| file == "./spec/su
 support_files.each { |f| require f }
 
 RSpec.configure do |config|
+  # rspec-expectations config goes here. You can use an alternate
+  # assertion/expectation library such as wrong or the stdlib/minitest
+  # assertions if you prefer.
+  config.expect_with :rspec do |expectations|
+    # This option will default to `true` in RSpec 4. It makes the `description`
+    # and `failure_message` of custom matchers include text for helper methods
+    # defined using `chain`, e.g.:
+    #     be_bigger_than(2).and_smaller_than(4).description
+    #     # => "be bigger than 2 and smaller than 4"
+    # ...rather than:
+    #     # => "be bigger than 2"
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  # rspec-mocks config goes here. You can use an alternate test double
+  # library (such as bogus or mocha) by changing the `mock_with` option here.
+  config.mock_with :rspec do |mocks|
+    # Prevents you from mocking or stubbing a method that does not exist on
+    # a real object. This is generally recommended, and will default to
+    # `true` in RSpec 4.
+    mocks.verify_partial_doubles = true
+  end
+
+  # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
+  # have no way to turn it off -- the option exists only for backwards
+  # compatibility in RSpec 3). It causes shared context metadata to be
+  # inherited by the metadata hash of host groups and examples, rather than
+  # triggering implicit auto-inclusion in groups with matching metadata.
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  # This allows you to limit a spec run to individual examples or groups
+  # you care about by tagging them with `:focus` metadata. When nothing
+  # is tagged with `:focus`, all examples get run. RSpec also provides
+  # aliases for `it`, `describe`, and `context` that include `:focus`
+  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  config.filter_run_when_matching :focus
+
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
   config.example_status_persistence_file_path = "spec/examples.txt"
 
-  # Disable RSpec exposing methods globally on `Module` and `main`
+  # Limits the available syntax to the non-monkey patched syntax that is
+  # recommended. For more details, see:
+  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
   config.disable_monkey_patching!
 
-  config.expect_with :rspec do |c|
-    c.syntax = :expect
-  end
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
+
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  Kernel.srand config.seed
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,9 +2,9 @@
 
 require "bundler/setup"
 
-# Test coverage reporting
-require "simplecov"
-SimpleCov.start
+# Require and run our simplecov initializer as the very first thing we do.
+# This is as per its docs https://github.com/colszowka/simplecov#getting-started
+require "./spec/support/simplecov"
 
 # Support debugging in the tests
 require "byebug"
@@ -17,10 +17,18 @@ require "dotenv/load"
 # validators file directly to load the content covered by our tests.
 require "defra_ruby/validators"
 
-# The following line is provided for convenience purposes. It has the downside
-# of increasing the boot-up time by auto-requiring all files in the support
-# directory. However in a small gem like this the increase should be neglible
-Dir[File.join(__dir__, "support", "**", "*.rb")].each { |f| require f }
+# Requires supporting ruby files with custom matchers and macros, etc, in
+# spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
+# run as spec files by default. This means that files in spec/support that end
+# in _spec.rb will both be required and run as specs, causing the specs to be
+# run twice. It is recommended that you do not name files matching this glob to
+# end with _spec.rb. You can configure this pattern with the --pattern
+# option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
+#
+# We make an exception for simplecov because that will already have been
+# required and run at the very top of spec_helper.rb
+support_files = Dir["./spec/support/**/*.rb"].reject { |file| file == "./spec/support/simplecov.rb" }
+support_files.each { |f| require f }
 
 RSpec.configure do |config|
   # Allows RSpec to persist some state between runs in order to support

--- a/spec/support/byebug.rb
+++ b/spec/support/byebug.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Support debugging in the tests
+require "byebug"

--- a/spec/support/defra_ruby_validators.rb
+++ b/spec/support/defra_ruby_validators.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+# Need to require our actual code files. We don't just require everything in
+# lib/defra_ruby because it contains the engine file which has a dependency on
+# rails. We don't have that as a dependency of this project because it is
+# a given this will be used in a rails project. So instead we require the
+# validators file directly to load the content covered by our tests.
+require "defra_ruby/validators"
+
 DefraRuby::Validators.configure do |c|
   def raise_missing_env_var(variable)
     raise("Environment variable #{variable} has not been set")

--- a/spec/support/dotenv.rb
+++ b/spec/support/dotenv.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Load env vars from a text file
+require "dotenv/load"

--- a/spec/support/simplecov.rb
+++ b/spec/support/simplecov.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "simplecov"
+
+# We start it with the rails param to ensure it includes coverage for all code
+# started by the rails app, and not just the files touched by our unit tests.
+# This gives us the most accurate assessment of our unit test coverage
+# https://github.com/colszowka/simplecov#getting-started
+SimpleCov.start do
+  # We filter the spec folder, mainly to ensure that any dummy apps don't get
+  # included in the coverage report. However our intent is that nothing in the
+  # spec folder should be included
+  add_filter "/spec/"
+  # The version file is simply just that, so we do not feel the need to ensure
+  # we have a test for it
+  add_filter "lib/defra_ruby/validators/version"
+end


### PR DESCRIPTION
Make rspec support structure consistent

We now have an agreed structure for rspec in our projects, where all additional tools and dependencies used within the test suite are initialized in separate files in the support folder rather than being referred to directly in the spec_helper.

This gem was put together before that agreement was put in place so this change just brings it inline with our other projects.