### PR TITLE
Remove byebug and swap it with pry-byebug

### DIFF
--- a/defra_ruby_validators.gemspec
+++ b/defra_ruby_validators.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
   # Use rest-client for external requests, eg. to Companies House
   spec.add_dependency "rest-client", "~> 2.0"
 
-  spec.add_development_dependency "byebug"
   spec.add_development_dependency "defra_ruby_style"
   # Shim to load environment variables from a .env file into ENV
   spec.add_development_dependency "dotenv"
@@ -48,6 +47,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "github_changelog_generator"
   # Allows us to check in our tests that the right message is being picked up
   spec.add_development_dependency "i18n"
+  # Adds step-by-step debugging and stack navigation capabilities to pry using
+  # byebug
+  spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop"

--- a/spec/support/byebug.rb
+++ b/spec/support/byebug.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-# Support debugging in the tests
-require "byebug"

--- a/spec/support/pry.rb
+++ b/spec/support/pry.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Support debugging in the tests. Add `binding.pry` wherever you want execution
+# to stop and the debugger to kick in.
+# Details on the debugging commands can be found here
+# https://github.com/deivid-rodriguez/pry-byebug#commands
+require "pry-byebug"


### PR DESCRIPTION
[Byebug](https://github.com/deivid-rodriguez/byebug) has a very similar interface to [GDB](https://www.gnu.org/software/gdb/), but **byebug** does not use the powerful [Pry](https://github.com/pry/pry) REPL.

You can stop execution in an app using **pry** with the `binding.pry` command but you then don't have the same features **byebug** offers.

[pry-byebug](https://github.com/deivid-rodriguez/pry-byebug) brings the best of both worlds hence this change to switch to using it.

Credit for highlighting this tool goes to [GitLab](https://docs.gitlab.com/ee/development/pry_debugging.html#byebug-vs-bindingpry).