### PR TITLE
Add base validator class

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,15 @@ validates :company_no, "defra_ruby/validators/companies_house_number": true
 A locale hint plus help text is also available for your views, that details what a registration number is and the restrictions, e.g
 
 ```erb
-  <span class="form-hint"><%= t("defra_ruby.validators.companies_house_number.hint") %></span>
+  <span class="form-hint"><%= t("defra_ruby.validators.CompaniesHouseNumberValidator.hint") %></span>
 
   <div class="form-group">
     <details>
       <summary>
-        <span class="summary"><%= t("defra_ruby.validators.companies_house_number.help.heading") %></span>
+        <span class="summary"><%= t("defra_ruby.validators.CompaniesHouseNumberValidator.help.heading") %></span>
       </summary>
       <div class="panel panel-border-narrow">
-        <p><%= t("defra_ruby.validators.companies_house_number.help.#{@form.business_type}") %></p>
+        <p><%= t("defra_ruby.validators.CompaniesHouseNumberValidator.help.#{@form.business_type}") %></p>
       </div>
     </details>
   </div>

--- a/config/locales/defra_ruby/validators/companies_house_number_validator/en.yml
+++ b/config/locales/defra_ruby/validators/companies_house_number_validator/en.yml
@@ -1,7 +1,7 @@
 en:
   defra_ruby:
     validators:
-      companies_house_number:
+      CompaniesHouseNumberValidator:
         hint: An 8 digit number, or 2 letters followed by a 6 digit number, or 2 letters followed by 5 digits and another letter
         help:
           heading: What's a registration number?

--- a/lib/defra_ruby/validators.rb
+++ b/lib/defra_ruby/validators.rb
@@ -6,6 +6,7 @@ require_relative "validators/version"
 require_relative "validators/configuration"
 require_relative "validators/companies_house_service"
 
+require_relative "validators/base_validator"
 require_relative "validators/companies_house_number_validator"
 
 module DefraRuby

--- a/lib/defra_ruby/validators/base_validator.rb
+++ b/lib/defra_ruby/validators/base_validator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module DefraRuby
+  module Validators
+    class BaseValidator < ActiveModel::EachValidator
+
+      protected
+
+      def error_message(error)
+        I18n.t("defra_ruby.validators.#{class_name}.errors.#{error}")
+      end
+
+      private
+
+      def class_name
+        self.class.name.split("::").last
+      end
+    end
+  end
+end

--- a/lib/defra_ruby/validators/companies_house_number_validator.rb
+++ b/lib/defra_ruby/validators/companies_house_number_validator.rb
@@ -2,7 +2,7 @@
 
 module DefraRuby
   module Validators
-    class CompaniesHouseNumberValidator < ActiveModel::EachValidator
+    class CompaniesHouseNumberValidator < BaseValidator
 
       # Examples we need to validate are
       # 10997904, 09764739
@@ -47,10 +47,6 @@ module DefraRuby
         end
       rescue StandardError
         record.errors[attribute] << error_message("error")
-      end
-
-      def error_message(error)
-        I18n.t("defra_ruby.validators.companies_house_number.errors.#{error}")
       end
 
     end


### PR DESCRIPTION
This is the first step in aligning the existing companies house validator with those in the [Waste Exemptions Engine](https://github.com/DEFRA/waste-exemptions-engine) prior to migrating them all into this gem.

They now make use of a base validator class which handles the error message for all validators. This change brings it in, though it tweaks the way the I18n translation for the error is identified.

In the engine currently they are identified by the object being validated e.g. business_type_form. In the gem it'll be easier to base the keys on the validator being used instead.

To support this we have added a private method that returns the name of the class without its namespace and updated the translation file to match.

One side effect is that we have to use a camelcase key rather than underscore in the locale files. We could have stuck with underscore, but we would then have had to add a further step to the `class_name()` method. This step would have involved copying the implementation of the [Rails ActiveSupport underscore](https://api.rubyonrails.org/classes/ActiveSupport/Inflector.html#method-i-underscore) or bringing in ActiveSupport as a dependency.

This seemed overkill to avoid having a camelcase key (`class_name()` will return `CompaniesHouseNumberValidator`) hence the update to the locale file.