### PR TITLE
Remove companies house number help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,23 +48,6 @@ Add it to your model or form object using
 validates :company_no, "defra_ruby/validators/companies_house_number": true
 ```
 
-A locale hint plus help text is also available for your views, that details what a registration number is and the restrictions, e.g
-
-```erb
-  <span class="form-hint"><%= t("defra_ruby.validators.CompaniesHouseNumberValidator.hint") %></span>
-
-  <div class="form-group">
-    <details>
-      <summary>
-        <span class="summary"><%= t("defra_ruby.validators.CompaniesHouseNumberValidator.help.heading") %></span>
-      </summary>
-      <div class="panel panel-border-narrow">
-        <p><%= t("defra_ruby.validators.CompaniesHouseNumberValidator.help.#{@form.business_type}") %></p>
-      </div>
-    </details>
-  </div>
-```
-
 ## Contributing to this project
 
 If you have an idea you'd like to contribute please log an issue.

--- a/config/locales/defra_ruby/validators/companies_house_number_validator/en.yml
+++ b/config/locales/defra_ruby/validators/companies_house_number_validator/en.yml
@@ -2,11 +2,6 @@ en:
   defra_ruby:
     validators:
       CompaniesHouseNumberValidator:
-        hint: An 8 digit number, or 2 letters followed by a 6 digit number, or 2 letters followed by 5 digits and another letter
-        help:
-          heading: What's a registration number?
-          limitedCompany: This is issued when the company is registered, and can be found on your Certificate of Incorporation and any paperwork from Companies House.
-          limitedLiabilityPartnership: This is issued when the limited liability partnership is registered, and can be found on your Certificate of Incorporation and any paperwork from Companies House.
         errors:
           blank: Enter a company registration number
           invalid: "Enter a valid number - it should have 8 digits, or 2 letters followed by 6 digits, or 2 letters followed by 5 digits and another letter. If your number has only 7 digits, enter it with a zero at the start."


### PR DESCRIPTION
There was an intention that this gem could also store some of the additional content used in a view such as hints and helper text, as this would enable sharing and avoid duplication.

In reality this is not being used, and if we did go this route we'd look at a more appropriate gem to do it in.

Hence this change removes it from the locale file and the README.