### PR TITLE
Add use of attribute to error message

### DIFF
--- a/config/locales/defra_ruby/validators/companies_house_number_validator/en.yml
+++ b/config/locales/defra_ruby/validators/companies_house_number_validator/en.yml
@@ -2,7 +2,7 @@ en:
   defra_ruby:
     validators:
       CompaniesHouseNumberValidator:
-        errors:
+        company_no:
           blank: Enter a company registration number
           invalid: "Enter a valid number - it should have 8 digits, or 2 letters followed by 6 digits, or 2 letters followed by 5 digits and another letter. If your number has only 7 digits, enter it with a zero at the start."
           not_found: Companies House couldn't find a company with this number

--- a/lib/defra_ruby/validators/base_validator.rb
+++ b/lib/defra_ruby/validators/base_validator.rb
@@ -6,8 +6,8 @@ module DefraRuby
 
       protected
 
-      def error_message(error)
-        I18n.t("defra_ruby.validators.#{class_name}.errors.#{error}")
+      def error_message(attribute, error)
+        I18n.t("defra_ruby.validators.#{class_name}.#{attribute}.#{error}")
       end
 
       private

--- a/lib/defra_ruby/validators/companies_house_number_validator.rb
+++ b/lib/defra_ruby/validators/companies_house_number_validator.rb
@@ -25,14 +25,14 @@ module DefraRuby
       def value_is_present?(record, attribute, value)
         return true if value.present?
 
-        record.errors[attribute] << error_message("blank")
+        record.errors[attribute] << error_message(attribute, "blank")
         false
       end
 
       def format_is_valid?(record, attribute, value)
         return true if value.match?(VALID_COMPANIES_HOUSE_REGISTRATION_NUMBER_REGEX)
 
-        record.errors[attribute] << error_message("invalid")
+        record.errors[attribute] << error_message(attribute, "invalid")
         false
       end
 
@@ -41,12 +41,12 @@ module DefraRuby
         when :active
           true
         when :inactive
-          record.errors[attribute] << error_message("inactive")
+          record.errors[attribute] << error_message(attribute, "inactive")
         when :not_found
-          record.errors[attribute] << error_message("not_found")
+          record.errors[attribute] << error_message(attribute, "not_found")
         end
       rescue StandardError
-        record.errors[attribute] << error_message("error")
+        record.errors[attribute] << error_message(attribute, "error")
       end
 
     end


### PR DESCRIPTION
When we copied the base validator from WEX in [PR #10](https://github.com/DEFRA/defra-ruby-validators/pull/10) we dropped the use of the `attribute` param because it didn't appear to be needed.

However with the benefit of hindsight we've realised that there are some validators which are handling more than one attribute, e.g. validating a person's name using first and last name attributes.

Those validators are not part of the gem yet, but they soon will be so it makes sense to correct our refactoring of the `BaseValidator.error_message` to handle attributes.

In the locales we've chosen to drop the key `errors` because with [PR #11](https://github.com/DEFRA/defra-ruby-validators/pull/11) our locales will now only contain error messages. So this updates the Companies House validation messages to work with the use of an attribute, we do a straight swap for `errors:` to `company_no:`.