### PR TITLE
Refactor Companies House Validator unit tests

### DIFF
--- a/lib/defra_ruby/validators/base_validator.rb
+++ b/lib/defra_ruby/validators/base_validator.rb
@@ -15,6 +15,7 @@ module DefraRuby
       def class_name
         self.class.name.split("::").last
       end
+
     end
   end
 end

--- a/spec/support/helpers/translator.rb
+++ b/spec/support/helpers/translator.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Helpers
+  module Translator
+    def self.error_message(klass, attribute, error)
+      class_name = klass_name(klass)
+      I18n.t("defra_ruby.validators.#{class_name}.#{attribute}.#{error}")
+    end
+
+    def self.klass_name(klass)
+      klass.name.split("::").last
+    end
+  end
+end

--- a/spec/support/shared_examples/validators/invalid_record.rb
+++ b/spec/support/shared_examples/validators/invalid_record.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "an invalid record" do |validatable, property, error_message|
+  it "confirms the object is invalid" do
+    expect(validatable).to_not be_valid
+  end
+
+  it "adds a single validation error to the record" do
+    validatable.valid?
+    expect(validatable.errors[property].count).to eq(1)
+  end
+
+  it "adds an appropriate validation error" do
+    validatable.valid?
+    expect(error_message).to_not include("translation missing:")
+    expect(validatable.errors[property]).to eq([error_message])
+  end
+end

--- a/spec/support/shared_examples/validators/valid_record.rb
+++ b/spec/support/shared_examples/validators/valid_record.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "a valid record" do |validatable|
+  it "confirms the object is valid" do
+    expect(validatable).to be_valid
+  end
+
+  it "the errors are empty" do
+    validatable.valid?
+    expect(validatable.errors).to be_empty
+  end
+end

--- a/spec/support/shared_examples/validators/validator.rb
+++ b/spec/support/shared_examples/validators/validator.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "a validator" do
+  it "is a type of BaseValidator" do
+    expect(described_class.ancestors)
+      .to include(DefraRuby::Validators::BaseValidator)
+  end
+end


### PR DESCRIPTION
This change refactors the existing companies house unit tests to make use of shared examples.

The shared examples have been directly taken from the waste exemptions engine where work was done to remove the duplication in the validation tests.

This is the final step in preparing this project for migrating the rest of the validators in WEX to this gem.