### PR TITLE
Make attribute optional in error message

### DIFF
--- a/lib/defra_ruby/validators/base_validator.rb
+++ b/lib/defra_ruby/validators/base_validator.rb
@@ -6,8 +6,10 @@ module DefraRuby
 
       protected
 
-      def error_message(attribute, error)
-        I18n.t("defra_ruby.validators.#{class_name}.#{attribute}.#{error}")
+      def error_message(attribute: nil, error:)
+        return I18n.t("defra_ruby.validators.#{class_name}.#{attribute}.#{error}") if attribute
+
+        I18n.t("defra_ruby.validators.#{class_name}.#{error}")
       end
 
       private

--- a/lib/defra_ruby/validators/companies_house_number_validator.rb
+++ b/lib/defra_ruby/validators/companies_house_number_validator.rb
@@ -25,14 +25,14 @@ module DefraRuby
       def value_is_present?(record, attribute, value)
         return true if value.present?
 
-        record.errors[attribute] << error_message(attribute, "blank")
+        record.errors[attribute] << error_message(attribute: attribute, error: "blank")
         false
       end
 
       def format_is_valid?(record, attribute, value)
         return true if value.match?(VALID_COMPANIES_HOUSE_REGISTRATION_NUMBER_REGEX)
 
-        record.errors[attribute] << error_message(attribute, "invalid")
+        record.errors[attribute] << error_message(attribute: attribute, error: "invalid")
         false
       end
 
@@ -41,12 +41,12 @@ module DefraRuby
         when :active
           true
         when :inactive
-          record.errors[attribute] << error_message(attribute, "inactive")
+          record.errors[attribute] << error_message(attribute: attribute, error: "inactive")
         when :not_found
-          record.errors[attribute] << error_message(attribute, "not_found")
+          record.errors[attribute] << error_message(attribute: attribute, error: "not_found")
         end
       rescue StandardError
-        record.errors[attribute] << error_message(attribute, "error")
+        record.errors[attribute] << error_message(attribute: attribute, error: "error")
       end
 
     end

--- a/spec/cassettes/company_no_inactive.yml
+++ b/spec/cassettes/company_no_inactive.yml
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin18.5.0 x86_64) ruby/2.4.2p198
+      - rest-client/2.0.2 (darwin18.2.0 x86_64) ruby/2.4.2p198
       Host:
       - api.companieshouse.gov.uk
       Authorization:
@@ -39,7 +39,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 May 2019 10:51:59 GMT
+      - Tue, 04 Jun 2019 22:42:41 GMT
       Pragma:
       - no-cache
       Server:
@@ -47,9 +47,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '600'
       X-Ratelimit-Remain:
-      - '597'
+      - '599'
       X-Ratelimit-Reset:
-      - '1557745019'
+      - '1559688461'
       X-Ratelimit-Window:
       - 5m
       Content-Length:
@@ -63,5 +63,5 @@ http_interactions:
         Elizabeth House","address_line_2":"54-58 High Street"},"undeliverable_registered_office_address":false,"company_name":"DIRECT
         SKIPS UK LTD","annual_return":{"last_made_up_to":"2014-06-11"},"jurisdiction":"england-wales","etag":"1cdef5bc2a020b3e9003b086033b64b78bcb28f6","company_status":"dissolved","has_insolvency_history":false,"has_charges":false,"links":{"self":"/company/07281919","filing_history":"/company/07281919/filing-history","officers":"/company/07281919/officers"},"date_of_cessation":"2016-01-05","can_file":false}'
     http_version: 
-  recorded_at: Mon, 13 May 2019 10:51:59 GMT
+  recorded_at: Tue, 04 Jun 2019 22:42:41 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/company_no_not_found.yml
+++ b/spec/cassettes/company_no_not_found.yml
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin18.5.0 x86_64) ruby/2.4.2p198
+      - rest-client/2.0.2 (darwin18.2.0 x86_64) ruby/2.4.2p198
       Host:
       - api.companieshouse.gov.uk
       Authorization:
@@ -39,7 +39,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 May 2019 10:51:59 GMT
+      - Tue, 04 Jun 2019 22:42:41 GMT
       Pragma:
       - no-cache
       Server:
@@ -49,7 +49,7 @@ http_interactions:
       X-Ratelimit-Remain:
       - '598'
       X-Ratelimit-Reset:
-      - '1557745019'
+      - '1559688461'
       X-Ratelimit-Window:
       - 5m
       Content-Length:
@@ -60,5 +60,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"errors":[{"type":"ch:service","error":"company-profile-not-found"}]}'
     http_version: 
-  recorded_at: Mon, 13 May 2019 10:51:59 GMT
+  recorded_at: Tue, 04 Jun 2019 22:42:41 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/company_no_valid.yml
+++ b/spec/cassettes/company_no_valid.yml
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin18.5.0 x86_64) ruby/2.4.2p198
+      - rest-client/2.0.2 (darwin18.2.0 x86_64) ruby/2.4.2p198
       Host:
       - api.companieshouse.gov.uk
       Authorization:
@@ -39,7 +39,7 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 13 May 2019 10:51:59 GMT
+      - Tue, 04 Jun 2019 22:42:41 GMT
       Pragma:
       - no-cache
       Server:
@@ -47,9 +47,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '600'
       X-Ratelimit-Remain:
-      - '599'
+      - '597'
       X-Ratelimit-Reset:
-      - '1557745019'
+      - '1559688461'
       X-Ratelimit-Window:
       - 5m
       Content-Length:
@@ -61,5 +61,5 @@ http_interactions:
       string: '{"type":"ltd","company_name":"0800 WASTE LTD.","has_insolvency_history":false,"accounts":{"next_due":"2019-09-30","next_made_up_to":"2018-12-31","next_accounts":{"overdue":false,"period_start_on":"2018-01-01","due_on":"2019-09-30","period_end_on":"2018-12-31"},"accounting_reference_date":{"month":"12","day":"31"},"last_accounts":{"period_end_on":"2017-12-31","period_start_on":"2017-01-01","made_up_to":"2017-12-31"},"overdue":false},"undeliverable_registered_office_address":false,"etag":"0ec9d00cab0ffee2ef1f5d59f4f714fa5b1618f5","company_number":"09360070","registered_office_address":{"postal_code":"SM3
         9ND","locality":"Sutton","region":"Surrey","address_line_1":"21 Haslam Avenue"},"jurisdiction":"england-wales","date_of_creation":"2014-12-18","company_status":"active","has_charges":false,"sic_codes":["38110"],"last_full_members_list_date":"2015-12-18","confirmation_statement":{"overdue":false,"next_made_up_to":"2020-01-23","last_made_up_to":"2019-01-23","next_due":"2020-02-06"},"links":{"self":"/company/09360070","filing_history":"/company/09360070/filing-history","officers":"/company/09360070/officers"},"registered_office_is_in_dispute":false,"can_file":true}'
     http_version: 
-  recorded_at: Mon, 13 May 2019 10:51:58 GMT
+  recorded_at: Tue, 04 Jun 2019 22:42:41 GMT
 recorded_with: VCR 4.0.0

--- a/spec/defra_ruby/validators/companies_house_number_validator_spec.rb
+++ b/spec/defra_ruby/validators/companies_house_number_validator_spec.rb
@@ -37,14 +37,22 @@ module DefraRuby
         context "when given an invalid company number" do
           context "because it is blank" do
             validatable = Test::CompaniesHouseNumberValidatable.new
-            error_message = Helpers::Translator.error_message(CompaniesHouseNumberValidator, :company_no, :blank)
+            error_message = Helpers::Translator.error_message(
+              klass: CompaniesHouseNumberValidator,
+              attribute: :company_no,
+              error: :blank
+            )
 
             it_behaves_like "an invalid record", validatable, :company_no, error_message
           end
 
           context "because the format is wrong" do
             validatable = Test::CompaniesHouseNumberValidatable.new(invalid_format_number)
-            error_message = Helpers::Translator.error_message(CompaniesHouseNumberValidator, :company_no, :invalid)
+            error_message = Helpers::Translator.error_message(
+              klass: CompaniesHouseNumberValidator,
+              attribute: :company_no,
+              error: :invalid
+            )
 
             it_behaves_like "an invalid record", validatable, :company_no, error_message
           end
@@ -55,7 +63,11 @@ module DefraRuby
             end
 
             validatable = Test::CompaniesHouseNumberValidatable.new(unknown_number)
-            error_message = Helpers::Translator.error_message(CompaniesHouseNumberValidator, :company_no, :not_found)
+            error_message = Helpers::Translator.error_message(
+              klass: CompaniesHouseNumberValidator,
+              attribute: :company_no,
+              error: :not_found
+            )
 
             it_behaves_like "an invalid record", validatable, :company_no, error_message
           end
@@ -66,7 +78,11 @@ module DefraRuby
             end
 
             validatable = Test::CompaniesHouseNumberValidatable.new(inactive_number)
-            error_message = Helpers::Translator.error_message(CompaniesHouseNumberValidator, :company_no, :inactive)
+            error_message = Helpers::Translator.error_message(
+              klass: CompaniesHouseNumberValidator,
+              attribute: :company_no,
+              error: :inactive
+            )
 
             it_behaves_like "an invalid record", validatable, :company_no, error_message
           end
@@ -78,7 +94,11 @@ module DefraRuby
           end
 
           validatable = Test::CompaniesHouseNumberValidatable.new(valid_numbers.sample)
-          error_message = Helpers::Translator.error_message(CompaniesHouseNumberValidator, :company_no, :error)
+          error_message = Helpers::Translator.error_message(
+            klass: CompaniesHouseNumberValidator,
+            attribute: :company_no,
+            error: :error
+          )
 
           it_behaves_like "an invalid record", validatable, :company_no, error_message
         end

--- a/spec/support/helpers/translator.rb
+++ b/spec/support/helpers/translator.rb
@@ -2,9 +2,11 @@
 
 module Helpers
   module Translator
-    def self.error_message(klass, attribute, error)
+    def self.error_message(klass:, attribute: nil, error:)
       class_name = klass_name(klass)
-      I18n.t("defra_ruby.validators.#{class_name}.#{attribute}.#{error}")
+      return I18n.t("defra_ruby.validators.#{class_name}.#{attribute}.#{error}") if attribute
+
+      I18n.t("defra_ruby.validators.#{class_name}.#{error}")
     end
 
     def self.klass_name(klass)


### PR DESCRIPTION
We are looking to add our next validation which will be a TrueFalseValidator (referred to as YesNoValidator in other projects though the valid values are true and false hence the rename).

It only has the one attribute to be checked, and that attribute will change depending on what the validator has been assigned to.

So as far as our the translations are concerned, we don't need or want to know what the attribute is called. This means we can't rely on it existing as a key in the locale yml file, and therefore cannot use it in our call to I18n.

So this change updates the base validator to make the params to `error_message()` both named and optional. It can then determine how to format the call to I18n based on whether the attribute param has been passed in.

N.B. This also updates the VCR cassettes.