### PR TITLE
Add new TrueFalseValidator

### DIFF
--- a/config/locales/defra_ruby/validators/true_false_validator/en.yml
+++ b/config/locales/defra_ruby/validators/true_false_validator/en.yml
@@ -1,0 +1,5 @@
+en:
+  defra_ruby:
+    validators:
+      TrueFalseValidator:
+        inclusion: "You must answer this question"

--- a/defra_ruby_validators.gemspec
+++ b/defra_ruby_validators.gemspec
@@ -32,6 +32,10 @@ Gem::Specification.new do |spec|
   # Include ActiveModel so that we have access to ActiveModel::Validations
   # ActiveModel::Validation is the central class within gem!
   spec.add_dependency "activemodel"
+  # Include ActiveSupport so that we have access to ActiveSupport::Concern
+  # and can then use concerns over modules for shared functionality between
+  # the validators
+  spec.add_dependency "activesupport"
   # Use rest-client for external requests, eg. to Companies House
   spec.add_dependency "rest-client", "~> 2.0"
 

--- a/lib/defra_ruby/validators.rb
+++ b/lib/defra_ruby/validators.rb
@@ -6,8 +6,11 @@ require_relative "validators/version"
 require_relative "validators/configuration"
 require_relative "validators/companies_house_service"
 
+require_relative "validators/concerns/can_validate_selection"
+
 require_relative "validators/base_validator"
 require_relative "validators/companies_house_number_validator"
+require_relative "validators/true_false_validator"
 
 module DefraRuby
   module Validators

--- a/lib/defra_ruby/validators/concerns/can_validate_selection.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_selection.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module DefraRuby
+  module Validators
+    module CanValidateSelection
+      extend ActiveSupport::Concern
+
+      included do
+        private
+
+        def value_is_included?(record, attribute, value, valid_options)
+          return true if value.present? && valid_options.include?(value)
+
+          record.errors[attribute] << error_message(error: "inclusion")
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/defra_ruby/validators/true_false_validator.rb
+++ b/lib/defra_ruby/validators/true_false_validator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module DefraRuby
+  module Validators
+    class TrueFalseValidator < BaseValidator
+      include CanValidateSelection
+
+      def validate_each(record, attribute, value)
+        valid_options = %w[true false]
+
+        value_is_included?(record, attribute, value, valid_options)
+      end
+    end
+  end
+end

--- a/spec/defra_ruby/validators/true_false_validator_spec.rb
+++ b/spec/defra_ruby/validators/true_false_validator_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Test
+  TrueFalseValidatable = Struct.new(:response) do
+    include ActiveModel::Validations
+
+    validates :response, "defra_ruby/validators/true_false": true
+  end
+end
+
+module DefraRuby
+  module Validators
+    RSpec.describe TrueFalseValidator do
+
+      valid_value = %w[true false].sample
+
+      it_behaves_like "a validator"
+      it_behaves_like "a selection validator", TrueFalseValidator, Test::TrueFalseValidatable, :response, valid_value
+    end
+  end
+end

--- a/spec/support/shared_examples/validators/selection_validator.rb
+++ b/spec/support/shared_examples/validators/selection_validator.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "a selection validator" do |validator, validatable_class, property, valid_value|
+  it "includes CanValidateSelection" do
+    included_modules = described_class.ancestors.select { |ancestor| ancestor.instance_of?(Module) }
+
+    expect(included_modules)
+      .to include(DefraRuby::Validators::CanValidateSelection)
+  end
+
+  describe "#validate_each" do
+    context "when the #{property} is valid" do
+      it_behaves_like "a valid record", validatable_class.new(valid_value)
+    end
+
+    context "when the #{property} is not valid" do
+      context "because the #{property} is not present" do
+        validatable = validatable_class.new
+        error_message = Helpers::Translator.error_message(klass: validator, error: :inclusion)
+
+        it_behaves_like "an invalid record", validatable, property, error_message
+      end
+
+      context "because the #{property} is not from an approved list" do
+        validatable = validatable_class.new("unexpected_#{property}")
+        error_message = Helpers::Translator.error_message(klass: validator, error: :inclusion)
+
+        it_behaves_like "an invalid record", validatable, property, error_message
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is essentially a copy and paste of the `YesNoValidator` from [waste-exemptions-engine](https://github.com/DEFRA/waste-exemptions-engine).

The intention is to replace it with this one in our validators gem, however when we migrated it across we spotted that the values it actually checks against are `true` and `false`. Therefore it made sense as part of the migration to rename the validator based on what it's actually checking against.

We also bring in our first [concern](https://api.rubyonrails.org/classes/ActiveSupport/Concern.html) as there will be other 'selection' based validators to be migrated, and the concern allows us to share code between them.