### PR TITLE
Add BusinessTypeValidator

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ bundle install
 
 With this gem installed, a number of active model based validators become available.
 
+### Business type
+
+This validator checks the value provided is one of our known business types (soleTrader, limitedCompany, partnership, limitedLiabilityPartnership, localAuthority, and charity). If blank or not one of these it will return an error.
+
+Add it to your model or form object using
+
+```ruby
+validates :company_no, "defra_ruby/validators/business_type": true
+```
+
 ### Companies House number
 
 This validator checks the company registration number provided. Specifically it first checks that it matches a known format. All registration numbers are 8 characters long but can be formatted in the following ways.

--- a/config/locales/defra_ruby/validators/business_type_validator/en.yml
+++ b/config/locales/defra_ruby/validators/business_type_validator/en.yml
@@ -1,0 +1,5 @@
+en:
+  defra_ruby:
+    validators:
+      BusinessTypeValidator:
+        inclusion: "You must answer this question"

--- a/lib/defra_ruby/validators.rb
+++ b/lib/defra_ruby/validators.rb
@@ -9,6 +9,7 @@ require_relative "validators/companies_house_service"
 require_relative "validators/concerns/can_validate_selection"
 
 require_relative "validators/base_validator"
+require_relative "validators/business_type_validator"
 require_relative "validators/companies_house_number_validator"
 require_relative "validators/true_false_validator"
 

--- a/lib/defra_ruby/validators/business_type_validator.rb
+++ b/lib/defra_ruby/validators/business_type_validator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module DefraRuby
+  module Validators
+    class BusinessTypeValidator < BaseValidator
+      include CanValidateSelection
+
+      def validate_each(record, attribute, value)
+        valid_options = %w[soleTrader limitedCompany partnership limitedLiabilityPartnership localAuthority charity]
+
+        value_is_included?(record, attribute, value, valid_options)
+      end
+    end
+  end
+end

--- a/spec/defra_ruby/validators/business_type_validator_spec.rb
+++ b/spec/defra_ruby/validators/business_type_validator_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Test
+  BusinessTypeValidatable = Struct.new(:response) do
+    include ActiveModel::Validations
+
+    validates :response, "defra_ruby/validators/business_type": true
+  end
+end
+
+module DefraRuby
+  module Validators
+    RSpec.describe BusinessTypeValidator do
+
+      valid_value = %w[soleTrader limitedCompany partnership limitedLiabilityPartnership localAuthority charity].sample
+
+      it_behaves_like "a validator"
+      it_behaves_like(
+        "a selection validator",
+        BusinessTypeValidator,
+        Test::BusinessTypeValidatable,
+        :response,
+        valid_value
+      )
+    end
+  end
+end


### PR DESCRIPTION
This is essentially a copy and paste of the validator from [waste-exemptions-engine](https://github.com/DEFRA/waste-exemptions-engine).

Adding it here means we can begin to share the validator across our services.