### PR TITLE
Add token validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This validator checks the value provided is one of our known business types (sol
 Add it to your model or form object using
 
 ```ruby
-validates :company_no, "defra_ruby/validators/business_type": true
+validates :business_type, "defra_ruby/validators/business_type": true
 ```
 
 ### Companies House number
@@ -58,6 +58,16 @@ Add it to your model or form object using
 validates :company_no, "defra_ruby/validators/companies_house_number": true
 ```
 
+### Token
+
+This validator checks the value is present and in the correct format, which in this case is that the value has a length of 24. If blank or not in a valid format it will return an error.
+
+Add it to your model or form object using
+
+```ruby
+validates :token, "defra_ruby/validators/token": true
+```
+
 ### True or false
 
 This validator checks the value provided is either `"true"` or `"false"`. If blank or not one of these it will return an error.
@@ -65,7 +75,7 @@ This validator checks the value provided is either `"true"` or `"false"`. If bla
 Add it to your model or form object using
 
 ```ruby
-validates :company_no, "defra_ruby/validators/true_false": true
+validates :is_a_farmer, "defra_ruby/validators/true_false": true
 ```
 
 ## Contributing to this project

--- a/config/locales/defra_ruby/validators/token_validator/en.yml
+++ b/config/locales/defra_ruby/validators/token_validator/en.yml
@@ -1,0 +1,6 @@
+en:
+  defra_ruby:
+    validators:
+      TokenValidator:
+        invalid_format: "The token is not valid"
+        blank: "The token is missing"

--- a/lib/defra_ruby/validators.rb
+++ b/lib/defra_ruby/validators.rb
@@ -6,11 +6,13 @@ require_relative "validators/version"
 require_relative "validators/configuration"
 require_relative "validators/companies_house_service"
 
+require_relative "validators/concerns/can_validate_presence"
 require_relative "validators/concerns/can_validate_selection"
 
 require_relative "validators/base_validator"
 require_relative "validators/business_type_validator"
 require_relative "validators/companies_house_number_validator"
+require_relative "validators/token_validator"
 require_relative "validators/true_false_validator"
 
 module DefraRuby

--- a/lib/defra_ruby/validators/concerns/can_validate_presence.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_presence.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module DefraRuby
+  module Validators
+    module CanValidatePresence
+      extend ActiveSupport::Concern
+
+      included do
+        private
+
+        def value_is_present?(record, attribute, value)
+          return true if value.present?
+
+          record.errors[attribute] << error_message(error: "blank")
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/defra_ruby/validators/token_validator.rb
+++ b/lib/defra_ruby/validators/token_validator.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module DefraRuby
+  module Validators
+    class TokenValidator < BaseValidator
+      include CanValidatePresence
+
+      def validate_each(record, attribute, value)
+        return false unless value_is_present?(record, attribute, value)
+
+        valid_format?(record, attribute, value)
+      end
+
+      private
+
+      def valid_format?(record, attribute, value)
+        # The token is assumed to have been generated using
+        # https://github.com/robertomiranda/has_secure_token which creates
+        # 24-character unique tokens
+        return true if value.length == 24
+
+        record.errors[attribute] << error_message(error: "invalid_format")
+        false
+      end
+    end
+  end
+end

--- a/spec/defra_ruby/validators/token_validator_spec.rb
+++ b/spec/defra_ruby/validators/token_validator_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Test
+  TokenValidatable = Struct.new(:token) do
+    include ActiveModel::Validations
+
+    validates :token, "defra_ruby/validators/token": true
+  end
+end
+
+module DefraRuby
+  module Validators
+    RSpec.describe TokenValidator, type: :model do
+
+      invalid_token = "123456"
+
+      it_behaves_like "a validator"
+      it_behaves_like "a presence validator", TokenValidator, Test::TokenValidatable, :token
+
+      describe "#validate_each" do
+        context "when the token is not valid" do
+          context "because the token is not correctly formatted" do
+            validatable = Test::TokenValidatable.new(invalid_token)
+            error_message = Helpers::Translator.error_message(klass: TokenValidator, error: :invalid_format)
+
+            it_behaves_like "an invalid record", validatable, :token, error_message
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/validators/presence_validator.rb
+++ b/spec/support/shared_examples/validators/presence_validator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "a presence validator" do |validator, validatable_class, property|
+  it "includes CanValidatePresence" do
+    included_modules = described_class.ancestors.select { |ancestor| ancestor.instance_of?(Module) }
+
+    expect(included_modules)
+      .to include(DefraRuby::Validators::CanValidatePresence)
+  end
+
+  describe "#validate_each" do
+    context "when the #{property} is not valid" do
+      context "because the #{property} is not present" do
+        validatable = validatable_class.new
+        error_message = Helpers::Translator.error_message(klass: validator, error: :blank)
+
+        it_behaves_like "an invalid record", validatable, property, error_message
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is essentially a copy and paste of the validator from [waste-exemptions-engine](https://github.com/DEFRA/waste-exemptions-engine).

Adding it here means we can begin to share the validator across our services.