### PR TITLE
Add position validator plus chars & length concern

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ Add it to your model or form object using
 validates :company_no, "defra_ruby/validators/companies_house_number": true
 ```
 
+### Position
+
+This validator checks the value provided for 'position' i.e. someones role or title within an organisation. This is an optional field so the validator has to handle the value being blank. If it's not then it can be no longer than 70 characters and only include letters, spaces, commas, full stops, hyphens and apostrophes else it will return an error.
+
+Add it to your model or form object using
+
+```ruby
+validates :position, "defra_ruby/validators/position": true
+```
+
 ### Token
 
 This validator checks the value is present and in the correct format, which in this case is that the value has a length of 24. If blank or not in a valid format it will return an error.

--- a/config/locales/defra_ruby/validators/position_validator/en.yml
+++ b/config/locales/defra_ruby/validators/position_validator/en.yml
@@ -1,0 +1,6 @@
+en:
+  defra_ruby:
+    validators:
+      PositionValidator:
+        invalid: "The position must contain only letters, spaces, commas, full stops, hyphens and apostrophes"
+        too_long: "The position must have no more than 70 characters"

--- a/lib/defra_ruby/validators.rb
+++ b/lib/defra_ruby/validators.rb
@@ -6,12 +6,15 @@ require_relative "validators/version"
 require_relative "validators/configuration"
 require_relative "validators/companies_house_service"
 
+require_relative "validators/concerns/can_validate_characters"
+require_relative "validators/concerns/can_validate_length"
 require_relative "validators/concerns/can_validate_presence"
 require_relative "validators/concerns/can_validate_selection"
 
 require_relative "validators/base_validator"
 require_relative "validators/business_type_validator"
 require_relative "validators/companies_house_number_validator"
+require_relative "validators/position_validator"
 require_relative "validators/token_validator"
 require_relative "validators/true_false_validator"
 

--- a/lib/defra_ruby/validators/concerns/can_validate_characters.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_characters.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module DefraRuby
+  module Validators
+    module CanValidateCharacters
+      extend ActiveSupport::Concern
+
+      included do
+        private
+
+        def value_has_no_invalid_characters?(record, attribute, value)
+          # Name fields must contain only letters, spaces, commas, full stops, hyphens and apostrophes
+          return true if value.match?(/\A[-a-z\s,.']+\z/i)
+
+          record.errors[attribute] << error_message(error: "invalid")
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/defra_ruby/validators/concerns/can_validate_length.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_length.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module DefraRuby
+  module Validators
+    module CanValidateLength
+      extend ActiveSupport::Concern
+
+      included do
+        private
+
+        def value_is_not_too_long?(record, attribute, value, max_length)
+          return true if value.length <= max_length
+
+          record.errors[attribute] << error_message(error: "too_long")
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/defra_ruby/validators/position_validator.rb
+++ b/lib/defra_ruby/validators/position_validator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module DefraRuby
+  module Validators
+    class PositionValidator < BaseValidator
+      include CanValidateCharacters
+      include CanValidateLength
+
+      def validate_each(record, attribute, value)
+        # Position is an optional field so its immediately valid if it's blank
+        return true if value.blank?
+        return false unless value_has_no_invalid_characters?(record, attribute, value)
+
+        max_length = 70
+        value_is_not_too_long?(record, attribute, value, max_length)
+        value_has_no_invalid_characters?(record, attribute, value)
+      end
+
+    end
+  end
+end

--- a/spec/defra_ruby/validators/position_validator_spec.rb
+++ b/spec/defra_ruby/validators/position_validator_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Test
+  PositionValidatable = Struct.new(:position) do
+    include ActiveModel::Validations
+
+    validates :position, "defra_ruby/validators/position": true
+  end
+end
+
+module DefraRuby
+  module Validators
+    RSpec.describe PositionValidator, type: :model do
+
+      empty_position = ""
+      too_long_position = Helpers::TextGenerator.random_string(71) # The max length is 70.
+      invalid_position = "**Invalid_@_Position**"
+
+      it_behaves_like "a validator"
+      it_behaves_like "a length validator", PositionValidator, Test::PositionValidatable, :position, too_long_position
+      it_behaves_like "a characters validator", PositionValidator, Test::PositionValidatable, :position, invalid_position
+
+      describe "#validate_each" do
+        context "when the position is valid" do
+          context "despite being blank (because position is optional)" do
+            it_behaves_like "a valid record", Test::PositionValidatable.new(empty_position)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/helpers/text_generator.rb
+++ b/spec/support/helpers/text_generator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Helpers
+  module TextGenerator
+    def self.random_string(length)
+      random_string_from_sequence([("a".."z"), ("A".."Z")].map(&:to_a).flatten, length)
+    end
+
+    def self.random_number_string(length)
+      random_string_from_sequence(("0".."9").to_a, length)
+    end
+
+    def self.random_string_from_sequence(sequence, length)
+      (0...length).map { sequence[rand(sequence.length)] }.join
+    end
+  end
+end

--- a/spec/support/shared_examples/validators/characters_validator.rb
+++ b/spec/support/shared_examples/validators/characters_validator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "a characters validator" do |validator, validatable_class, property, invalid_input|
+  it "includes CanValidateCharacters" do
+    included_modules = described_class.ancestors.select { |ancestor| ancestor.instance_of?(Module) }
+
+    expect(included_modules)
+      .to include(DefraRuby::Validators::CanValidateCharacters)
+  end
+
+  describe "#validate_each" do
+    context "when the #{property} is not valid" do
+      context "because the #{property} is not correctly formatted" do
+        validatable = validatable_class.new(invalid_input)
+        error_message = Helpers::Translator.error_message(klass: validator, error: :invalid)
+
+        it_behaves_like "an invalid record", validatable, property, error_message
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/validators/length_validator.rb
+++ b/spec/support/shared_examples/validators/length_validator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "a length validator" do |validator, validatable_class, property, invalid_input|
+  it "includes CanValidateLength" do
+    included_modules = described_class.ancestors.select { |ancestor| ancestor.instance_of?(Module) }
+
+    expect(included_modules)
+      .to include(DefraRuby::Validators::CanValidateLength)
+  end
+
+  describe "#validate_each" do
+    context "when the #{property} is not valid" do
+      context "because the #{property} is too long" do
+        validatable = validatable_class.new(invalid_input)
+        error_message = Helpers::Translator.error_message(klass: validator, error: :too_long)
+
+        it_behaves_like "an invalid record", validatable, property, error_message
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is essentially a copy and paste of the validator from [waste-exemptions-engine](https://github.com/DEFRA/waste-exemptions-engine).

Adding it here means we can begin to share the validator across our services.

To support adding it we also copied over the `CanValidateLength` concern.

Finally as part of the refactoring when copying it over we took the opportunity to create the `CanValidateCharacters` concern. On review we could see that the position and person_name validators were duplicating `value_has_no_invalid_characters?()`.