### PR TITLE
Remove dependency on activesupport

### DIFF
--- a/defra_ruby_validators.gemspec
+++ b/defra_ruby_validators.gemspec
@@ -32,10 +32,6 @@ Gem::Specification.new do |spec|
   # Include ActiveModel so that we have access to ActiveModel::Validations
   # ActiveModel::Validation is the central class within gem!
   spec.add_dependency "activemodel"
-  # Include ActiveSupport so that we have access to ActiveSupport::Concern
-  # and can then use concerns over modules for shared functionality between
-  # the validators
-  spec.add_dependency "activesupport"
   # Use rest-client for external requests, eg. to Companies House
   spec.add_dependency "rest-client", "~> 2.0"
 

--- a/lib/defra_ruby/validators/concerns/can_validate_characters.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_characters.rb
@@ -3,19 +3,17 @@
 module DefraRuby
   module Validators
     module CanValidateCharacters
-      extend ActiveSupport::Concern
 
-      included do
-        private
+      private
 
-        def value_has_no_invalid_characters?(record, attribute, value)
-          # Name fields must contain only letters, spaces, commas, full stops, hyphens and apostrophes
-          return true if value.match?(/\A[-a-z\s,.']+\z/i)
+      def value_has_no_invalid_characters?(record, attribute, value)
+        # Name fields must contain only letters, spaces, commas, full stops, hyphens and apostrophes
+        return true if value.match?(/\A[-a-z\s,.']+\z/i)
 
-          record.errors[attribute] << error_message(error: "invalid")
-          false
-        end
+        record.errors[attribute] << error_message(error: "invalid")
+        false
       end
+
     end
   end
 end

--- a/lib/defra_ruby/validators/concerns/can_validate_length.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_length.rb
@@ -3,18 +3,16 @@
 module DefraRuby
   module Validators
     module CanValidateLength
-      extend ActiveSupport::Concern
 
-      included do
-        private
+      private
 
-        def value_is_not_too_long?(record, attribute, value, max_length)
-          return true if value.length <= max_length
+      def value_is_not_too_long?(record, attribute, value, max_length)
+        return true if value.length <= max_length
 
-          record.errors[attribute] << error_message(error: "too_long")
-          false
-        end
+        record.errors[attribute] << error_message(error: "too_long")
+        false
       end
+
     end
   end
 end

--- a/lib/defra_ruby/validators/concerns/can_validate_presence.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_presence.rb
@@ -3,18 +3,16 @@
 module DefraRuby
   module Validators
     module CanValidatePresence
-      extend ActiveSupport::Concern
 
-      included do
-        private
+      private
 
-        def value_is_present?(record, attribute, value)
-          return true if value.present?
+      def value_is_present?(record, attribute, value)
+        return true if value.present?
 
-          record.errors[attribute] << error_message(error: "blank")
-          false
-        end
+        record.errors[attribute] << error_message(error: "blank")
+        false
       end
+
     end
   end
 end

--- a/lib/defra_ruby/validators/concerns/can_validate_selection.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_selection.rb
@@ -3,18 +3,16 @@
 module DefraRuby
   module Validators
     module CanValidateSelection
-      extend ActiveSupport::Concern
 
-      included do
-        private
+      private
 
-        def value_is_included?(record, attribute, value, valid_options)
-          return true if value.present? && valid_options.include?(value)
+      def value_is_included?(record, attribute, value, valid_options)
+        return true if value.present? && valid_options.include?(value)
 
-          record.errors[attribute] << error_message(error: "inclusion")
-          false
-        end
+        record.errors[attribute] << error_message(error: "inclusion")
+        false
       end
+
     end
   end
 end


### PR DESCRIPTION
We brought in ActiveSupport as that is what [waste-exemptions](https://github.com/DEFRA/waste-exemptions-engine) used for its validation concerns.

However it raises a Hakiri warning

- CVE2015-3227
- Specially crafted XML documents can cause applications to raise a `SystemStackError` and potentially cause a denial
- Workarounds: Use an XML parser that is not impacted by this problem, such as Nokogiri or LibXML

Because our other projects are Rails based they automatically have Nokogiri and as such this appears to alleviate the issue with ActiveSupport.

However as just a gem, we don't want to solve the problem by adding an unnecessary dependency. Hence this change which drops ActiveSupport and reformats the 'concerns' to just be vanilla modules.