### PR TITLE
Always use an attribute in validations

### DIFF
--- a/config/locales/defra_ruby/validators/business_type_validator/en.yml
+++ b/config/locales/defra_ruby/validators/business_type_validator/en.yml
@@ -2,4 +2,5 @@ en:
   defra_ruby:
     validators:
       BusinessTypeValidator:
-        inclusion: "You must answer this question"
+        business_type:
+          inclusion: "You must answer this question"

--- a/config/locales/defra_ruby/validators/position_validator/en.yml
+++ b/config/locales/defra_ruby/validators/position_validator/en.yml
@@ -2,5 +2,6 @@ en:
   defra_ruby:
     validators:
       PositionValidator:
-        invalid: "The position must contain only letters, spaces, commas, full stops, hyphens and apostrophes"
-        too_long: "The position must have no more than 70 characters"
+        position:
+          invalid: "The position must contain only letters, spaces, commas, full stops, hyphens and apostrophes"
+          too_long: "The position must have no more than 70 characters"

--- a/config/locales/defra_ruby/validators/token_validator/en.yml
+++ b/config/locales/defra_ruby/validators/token_validator/en.yml
@@ -2,5 +2,6 @@ en:
   defra_ruby:
     validators:
       TokenValidator:
-        invalid_format: "The token is not valid"
-        blank: "The token is missing"
+        token:
+          invalid_format: "The token is not valid"
+          blank: "The token is missing"

--- a/config/locales/defra_ruby/validators/true_false_validator/en.yml
+++ b/config/locales/defra_ruby/validators/true_false_validator/en.yml
@@ -2,4 +2,5 @@ en:
   defra_ruby:
     validators:
       TrueFalseValidator:
-        inclusion: "You must answer this question"
+        attribute:
+          inclusion: "You must answer this question"

--- a/lib/defra_ruby/validators/base_validator.rb
+++ b/lib/defra_ruby/validators/base_validator.rb
@@ -6,10 +6,8 @@ module DefraRuby
 
       protected
 
-      def error_message(attribute: nil, error:)
-        return I18n.t("defra_ruby.validators.#{class_name}.#{attribute}.#{error}") if attribute
-
-        I18n.t("defra_ruby.validators.#{class_name}.#{error}")
+      def error_message(attribute, error)
+        I18n.t("defra_ruby.validators.#{class_name}.#{attribute}.#{error}")
       end
 
       private

--- a/lib/defra_ruby/validators/business_type_validator.rb
+++ b/lib/defra_ruby/validators/business_type_validator.rb
@@ -5,10 +5,10 @@ module DefraRuby
     class BusinessTypeValidator < BaseValidator
       include CanValidateSelection
 
-      def validate_each(record, attribute, value)
+      def validate_each(record, _attribute, value)
         valid_options = %w[soleTrader limitedCompany partnership limitedLiabilityPartnership localAuthority charity]
 
-        value_is_included?(record, attribute, value, valid_options)
+        value_is_included?(record, :business_type, value, valid_options)
       end
     end
   end

--- a/lib/defra_ruby/validators/companies_house_number_validator.rb
+++ b/lib/defra_ruby/validators/companies_house_number_validator.rb
@@ -25,14 +25,14 @@ module DefraRuby
       def value_is_present?(record, attribute, value)
         return true if value.present?
 
-        record.errors[attribute] << error_message(attribute: attribute, error: "blank")
+        record.errors[attribute] << error_message(:company_no, :blank)
         false
       end
 
       def format_is_valid?(record, attribute, value)
         return true if value.match?(VALID_COMPANIES_HOUSE_REGISTRATION_NUMBER_REGEX)
 
-        record.errors[attribute] << error_message(attribute: attribute, error: "invalid")
+        record.errors[attribute] << error_message(:company_no, :invalid)
         false
       end
 
@@ -41,12 +41,12 @@ module DefraRuby
         when :active
           true
         when :inactive
-          record.errors[attribute] << error_message(attribute: attribute, error: "inactive")
+          record.errors[attribute] << error_message(:company_no, :inactive)
         when :not_found
-          record.errors[attribute] << error_message(attribute: attribute, error: "not_found")
+          record.errors[attribute] << error_message(:company_no, :not_found)
         end
       rescue StandardError
-        record.errors[attribute] << error_message(attribute: attribute, error: "error")
+        record.errors[attribute] << error_message(:company_no, :error)
       end
 
     end

--- a/lib/defra_ruby/validators/concerns/can_validate_characters.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_characters.rb
@@ -10,7 +10,7 @@ module DefraRuby
         # Name fields must contain only letters, spaces, commas, full stops, hyphens and apostrophes
         return true if value.match?(/\A[-a-z\s,.']+\z/i)
 
-        record.errors[attribute] << error_message(error: "invalid")
+        record.errors[attribute] << error_message(attribute, :invalid)
         false
       end
 

--- a/lib/defra_ruby/validators/concerns/can_validate_length.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_length.rb
@@ -9,7 +9,7 @@ module DefraRuby
       def value_is_not_too_long?(record, attribute, value, max_length)
         return true if value.length <= max_length
 
-        record.errors[attribute] << error_message(error: "too_long")
+        record.errors[attribute] << error_message(attribute, :too_long)
         false
       end
 

--- a/lib/defra_ruby/validators/concerns/can_validate_presence.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_presence.rb
@@ -9,7 +9,7 @@ module DefraRuby
       def value_is_present?(record, attribute, value)
         return true if value.present?
 
-        record.errors[attribute] << error_message(error: "blank")
+        record.errors[attribute] << error_message(attribute, :blank)
         false
       end
 

--- a/lib/defra_ruby/validators/concerns/can_validate_selection.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_selection.rb
@@ -9,7 +9,7 @@ module DefraRuby
       def value_is_included?(record, attribute, value, valid_options)
         return true if value.present? && valid_options.include?(value)
 
-        record.errors[attribute] << error_message(error: "inclusion")
+        record.errors[attribute] << error_message(attribute, :inclusion)
         false
       end
 

--- a/lib/defra_ruby/validators/position_validator.rb
+++ b/lib/defra_ruby/validators/position_validator.rb
@@ -12,8 +12,8 @@ module DefraRuby
         return false unless value_has_no_invalid_characters?(record, attribute, value)
 
         max_length = 70
-        value_is_not_too_long?(record, attribute, value, max_length)
-        value_has_no_invalid_characters?(record, attribute, value)
+        value_is_not_too_long?(record, :position, value, max_length)
+        value_has_no_invalid_characters?(record, :position, value)
       end
 
     end

--- a/lib/defra_ruby/validators/token_validator.rb
+++ b/lib/defra_ruby/validators/token_validator.rb
@@ -19,7 +19,7 @@ module DefraRuby
         # 24-character unique tokens
         return true if value.length == 24
 
-        record.errors[attribute] << error_message(error: "invalid_format")
+        record.errors[attribute] << error_message(:token, :invalid_format)
         false
       end
     end

--- a/lib/defra_ruby/validators/true_false_validator.rb
+++ b/lib/defra_ruby/validators/true_false_validator.rb
@@ -5,10 +5,10 @@ module DefraRuby
     class TrueFalseValidator < BaseValidator
       include CanValidateSelection
 
-      def validate_each(record, attribute, value)
+      def validate_each(record, _attribute, value)
         valid_options = %w[true false]
 
-        value_is_included?(record, attribute, value, valid_options)
+        value_is_included?(record, :attribute, value, valid_options)
       end
     end
   end

--- a/spec/defra_ruby/validators/business_type_validator_spec.rb
+++ b/spec/defra_ruby/validators/business_type_validator_spec.rb
@@ -3,10 +3,10 @@
 require "spec_helper"
 
 module Test
-  BusinessTypeValidatable = Struct.new(:response) do
+  BusinessTypeValidatable = Struct.new(:business_type) do
     include ActiveModel::Validations
 
-    validates :response, "defra_ruby/validators/business_type": true
+    validates :business_type, "defra_ruby/validators/business_type": true
   end
 end
 
@@ -21,7 +21,7 @@ module DefraRuby
         "a selection validator",
         BusinessTypeValidator,
         Test::BusinessTypeValidatable,
-        :response,
+        :business_type,
         valid_value
       )
     end

--- a/spec/defra_ruby/validators/companies_house_number_validator_spec.rb
+++ b/spec/defra_ruby/validators/companies_house_number_validator_spec.rb
@@ -38,9 +38,9 @@ module DefraRuby
           context "because it is blank" do
             validatable = Test::CompaniesHouseNumberValidatable.new
             error_message = Helpers::Translator.error_message(
-              klass: CompaniesHouseNumberValidator,
-              attribute: :company_no,
-              error: :blank
+              CompaniesHouseNumberValidator,
+              :company_no,
+              :blank
             )
 
             it_behaves_like "an invalid record", validatable, :company_no, error_message
@@ -49,9 +49,9 @@ module DefraRuby
           context "because the format is wrong" do
             validatable = Test::CompaniesHouseNumberValidatable.new(invalid_format_number)
             error_message = Helpers::Translator.error_message(
-              klass: CompaniesHouseNumberValidator,
-              attribute: :company_no,
-              error: :invalid
+              CompaniesHouseNumberValidator,
+              :company_no,
+              :invalid
             )
 
             it_behaves_like "an invalid record", validatable, :company_no, error_message
@@ -64,9 +64,9 @@ module DefraRuby
 
             validatable = Test::CompaniesHouseNumberValidatable.new(unknown_number)
             error_message = Helpers::Translator.error_message(
-              klass: CompaniesHouseNumberValidator,
-              attribute: :company_no,
-              error: :not_found
+              CompaniesHouseNumberValidator,
+              :company_no,
+              :not_found
             )
 
             it_behaves_like "an invalid record", validatable, :company_no, error_message
@@ -79,9 +79,9 @@ module DefraRuby
 
             validatable = Test::CompaniesHouseNumberValidatable.new(inactive_number)
             error_message = Helpers::Translator.error_message(
-              klass: CompaniesHouseNumberValidator,
-              attribute: :company_no,
-              error: :inactive
+              CompaniesHouseNumberValidator,
+              :company_no,
+              :inactive
             )
 
             it_behaves_like "an invalid record", validatable, :company_no, error_message
@@ -95,9 +95,9 @@ module DefraRuby
 
           validatable = Test::CompaniesHouseNumberValidatable.new(valid_numbers.sample)
           error_message = Helpers::Translator.error_message(
-            klass: CompaniesHouseNumberValidator,
-            attribute: :company_no,
-            error: :error
+            CompaniesHouseNumberValidator,
+            :company_no,
+            :error
           )
 
           it_behaves_like "an invalid record", validatable, :company_no, error_message

--- a/spec/defra_ruby/validators/token_validator_spec.rb
+++ b/spec/defra_ruby/validators/token_validator_spec.rb
@@ -23,7 +23,7 @@ module DefraRuby
         context "when the token is not valid" do
           context "because the token is not correctly formatted" do
             validatable = Test::TokenValidatable.new(invalid_token)
-            error_message = Helpers::Translator.error_message(klass: TokenValidator, error: :invalid_format)
+            error_message = Helpers::Translator.error_message(TokenValidator, :token, :invalid_format)
 
             it_behaves_like "an invalid record", validatable, :token, error_message
           end

--- a/spec/defra_ruby/validators/true_false_validator_spec.rb
+++ b/spec/defra_ruby/validators/true_false_validator_spec.rb
@@ -3,10 +3,10 @@
 require "spec_helper"
 
 module Test
-  TrueFalseValidatable = Struct.new(:response) do
+  TrueFalseValidatable = Struct.new(:attribute) do
     include ActiveModel::Validations
 
-    validates :response, "defra_ruby/validators/true_false": true
+    validates :attribute, "defra_ruby/validators/true_false": true
   end
 end
 
@@ -17,7 +17,7 @@ module DefraRuby
       valid_value = %w[true false].sample
 
       it_behaves_like "a validator"
-      it_behaves_like "a selection validator", TrueFalseValidator, Test::TrueFalseValidatable, :response, valid_value
+      it_behaves_like "a selection validator", TrueFalseValidator, Test::TrueFalseValidatable, :attribute, valid_value
     end
   end
 end

--- a/spec/support/helpers/translator.rb
+++ b/spec/support/helpers/translator.rb
@@ -2,11 +2,10 @@
 
 module Helpers
   module Translator
-    def self.error_message(klass:, attribute: nil, error:)
+    def self.error_message(klass, attribute, error)
       class_name = klass_name(klass)
-      return I18n.t("defra_ruby.validators.#{class_name}.#{attribute}.#{error}") if attribute
 
-      I18n.t("defra_ruby.validators.#{class_name}.#{error}")
+      I18n.t("defra_ruby.validators.#{class_name}.#{attribute}.#{error}")
     end
 
     def self.klass_name(klass)

--- a/spec/support/shared_examples/validators/characters_validator.rb
+++ b/spec/support/shared_examples/validators/characters_validator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples "a characters validator" do |validator, validatable_class, property, invalid_input|
+RSpec.shared_examples "a characters validator" do |validator, validatable_class, attribute, invalid_input|
   it "includes CanValidateCharacters" do
     included_modules = described_class.ancestors.select { |ancestor| ancestor.instance_of?(Module) }
 
@@ -9,12 +9,12 @@ RSpec.shared_examples "a characters validator" do |validator, validatable_class,
   end
 
   describe "#validate_each" do
-    context "when the #{property} is not valid" do
-      context "because the #{property} is not correctly formatted" do
+    context "when the #{attribute} is not valid" do
+      context "because the #{attribute} is not correctly formatted" do
         validatable = validatable_class.new(invalid_input)
-        error_message = Helpers::Translator.error_message(klass: validator, error: :invalid)
+        error_message = Helpers::Translator.error_message(validator, attribute, :invalid)
 
-        it_behaves_like "an invalid record", validatable, property, error_message
+        it_behaves_like "an invalid record", validatable, attribute, error_message
       end
     end
   end

--- a/spec/support/shared_examples/validators/invalid_record.rb
+++ b/spec/support/shared_examples/validators/invalid_record.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples "an invalid record" do |validatable, property, error_message|
+RSpec.shared_examples "an invalid record" do |validatable, attribute, error_message|
   it "confirms the object is invalid" do
     expect(validatable).to_not be_valid
   end
 
   it "adds a single validation error to the record" do
     validatable.valid?
-    expect(validatable.errors[property].count).to eq(1)
+    expect(validatable.errors[attribute].count).to eq(1)
   end
 
   it "adds an appropriate validation error" do
     validatable.valid?
     expect(error_message).to_not include("translation missing:")
-    expect(validatable.errors[property]).to eq([error_message])
+    expect(validatable.errors[attribute]).to eq([error_message])
   end
 end

--- a/spec/support/shared_examples/validators/length_validator.rb
+++ b/spec/support/shared_examples/validators/length_validator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples "a length validator" do |validator, validatable_class, property, invalid_input|
+RSpec.shared_examples "a length validator" do |validator, validatable_class, attribute, invalid_input|
   it "includes CanValidateLength" do
     included_modules = described_class.ancestors.select { |ancestor| ancestor.instance_of?(Module) }
 
@@ -9,12 +9,12 @@ RSpec.shared_examples "a length validator" do |validator, validatable_class, pro
   end
 
   describe "#validate_each" do
-    context "when the #{property} is not valid" do
-      context "because the #{property} is too long" do
+    context "when the #{attribute} is not valid" do
+      context "because the #{attribute} is too long" do
         validatable = validatable_class.new(invalid_input)
-        error_message = Helpers::Translator.error_message(klass: validator, error: :too_long)
+        error_message = Helpers::Translator.error_message(validator, attribute, :too_long)
 
-        it_behaves_like "an invalid record", validatable, property, error_message
+        it_behaves_like "an invalid record", validatable, attribute, error_message
       end
     end
   end

--- a/spec/support/shared_examples/validators/presence_validator.rb
+++ b/spec/support/shared_examples/validators/presence_validator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples "a presence validator" do |validator, validatable_class, property|
+RSpec.shared_examples "a presence validator" do |validator, validatable_class, attribute|
   it "includes CanValidatePresence" do
     included_modules = described_class.ancestors.select { |ancestor| ancestor.instance_of?(Module) }
 
@@ -9,12 +9,12 @@ RSpec.shared_examples "a presence validator" do |validator, validatable_class, p
   end
 
   describe "#validate_each" do
-    context "when the #{property} is not valid" do
-      context "because the #{property} is not present" do
+    context "when the #{attribute} is not valid" do
+      context "because the #{attribute} is not present" do
         validatable = validatable_class.new
-        error_message = Helpers::Translator.error_message(klass: validator, error: :blank)
+        error_message = Helpers::Translator.error_message(validator, attribute, :blank)
 
-        it_behaves_like "an invalid record", validatable, property, error_message
+        it_behaves_like "an invalid record", validatable, attribute, error_message
       end
     end
   end

--- a/spec/support/shared_examples/validators/selection_validator.rb
+++ b/spec/support/shared_examples/validators/selection_validator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples "a selection validator" do |validator, validatable_class, property, valid_value|
+RSpec.shared_examples "a selection validator" do |validator, validatable_class, attribute, valid_value|
   it "includes CanValidateSelection" do
     included_modules = described_class.ancestors.select { |ancestor| ancestor.instance_of?(Module) }
 
@@ -9,23 +9,23 @@ RSpec.shared_examples "a selection validator" do |validator, validatable_class, 
   end
 
   describe "#validate_each" do
-    context "when the #{property} is valid" do
+    context "when the #{attribute} is valid" do
       it_behaves_like "a valid record", validatable_class.new(valid_value)
     end
 
-    context "when the #{property} is not valid" do
-      context "because the #{property} is not present" do
+    context "when the #{attribute} is not valid" do
+      context "because the #{attribute} is not present" do
         validatable = validatable_class.new
-        error_message = Helpers::Translator.error_message(klass: validator, error: :inclusion)
+        error_message = Helpers::Translator.error_message(validator, attribute, :inclusion)
 
-        it_behaves_like "an invalid record", validatable, property, error_message
+        it_behaves_like "an invalid record", validatable, attribute, error_message
       end
 
-      context "because the #{property} is not from an approved list" do
-        validatable = validatable_class.new("unexpected_#{property}")
-        error_message = Helpers::Translator.error_message(klass: validator, error: :inclusion)
+      context "because the #{attribute} is not from an approved list" do
+        validatable = validatable_class.new("unexpected_#{attribute}")
+        error_message = Helpers::Translator.error_message(validator, attribute, :inclusion)
 
-        it_behaves_like "an invalid record", validatable, property, error_message
+        it_behaves_like "an invalid record", validatable, attribute, error_message
       end
     end
   end


### PR DESCRIPTION
When initially putting together the first few validations, refactoring them from what was in the [waste-exemptions-engine](https://github.com/DEFRA/waste-exemptions-engine) we stripped out from the locales the named attributes as they did not seem necessary.

All we cared about was the error, because the validators we were migrating were checking a single attribute so what did it matter what it was called.

However the next ones we are looking to migrate and refactor cover multiple attributes. For example `PersonValidator` is checking both the first and last name. `EmailValidator` is checking both the main and confirmed email addresses. So this means when determining what error message to show we will need to know the attribute.

The problem we just spotted was that they also use some of the shared concerns we have created. When we refactored them we stripped out the dependency on needing to specify an attribute. But now we need to use them.

So rather than go more complex than we had already gone, this change updates all the current validators and their locales, plus the concerns, base class, and specs to always expect an attribute to determine the error message.