### PR TITLE
Ensure all validators & concerns validate

### DIFF
--- a/lib/defra_ruby/validators/position_validator.rb
+++ b/lib/defra_ruby/validators/position_validator.rb
@@ -6,13 +6,14 @@ module DefraRuby
       include CanValidateCharacters
       include CanValidateLength
 
+      MAX_LENGTH = 70
+
       def validate_each(record, attribute, value)
         # Position is an optional field so its immediately valid if it's blank
         return true if value.blank?
         return false unless value_has_no_invalid_characters?(record, attribute, value)
 
-        max_length = 70
-        value_is_not_too_long?(record, :position, value, max_length)
+        value_is_not_too_long?(record, :position, value, MAX_LENGTH)
         value_has_no_invalid_characters?(record, :position, value)
       end
 

--- a/spec/defra_ruby/validators/business_type_validator_spec.rb
+++ b/spec/defra_ruby/validators/business_type_validator_spec.rb
@@ -14,15 +14,16 @@ module DefraRuby
   module Validators
     RSpec.describe BusinessTypeValidator do
 
-      valid_value = %w[soleTrader limitedCompany partnership limitedLiabilityPartnership localAuthority charity].sample
+      valid_type = %w[soleTrader limitedCompany partnership limitedLiabilityPartnership localAuthority charity].sample
+      invalid_type = "coven"
 
-      it_behaves_like "a validator"
+      it_behaves_like("a validator")
       it_behaves_like(
         "a selection validator",
         BusinessTypeValidator,
         Test::BusinessTypeValidatable,
         :business_type,
-        valid_value
+        valid: valid_type, invalid: invalid_type
       )
     end
   end

--- a/spec/defra_ruby/validators/position_validator_spec.rb
+++ b/spec/defra_ruby/validators/position_validator_spec.rb
@@ -14,13 +14,26 @@ module DefraRuby
   module Validators
     RSpec.describe PositionValidator, type: :model do
 
-      empty_position = ""
-      too_long_position = Helpers::TextGenerator.random_string(71) # The max length is 70.
+      valid_position = "Padawan"
+      too_long_position = Helpers::TextGenerator.random_string(PositionValidator::MAX_LENGTH + 1)
       invalid_position = "**Invalid_@_Position**"
+      empty_position = ""
 
-      it_behaves_like "a validator"
-      it_behaves_like "a length validator", PositionValidator, Test::PositionValidatable, :position, too_long_position
-      it_behaves_like "a characters validator", PositionValidator, Test::PositionValidatable, :position, invalid_position
+      it_behaves_like("a validator")
+      it_behaves_like(
+        "a length validator",
+        PositionValidator,
+        Test::PositionValidatable,
+        :position,
+        valid: valid_position, invalid: too_long_position
+      )
+      it_behaves_like(
+        "a characters validator",
+        PositionValidator,
+        Test::PositionValidatable,
+        :position,
+        valid: valid_position, invalid: invalid_position
+      )
 
       describe "#validate_each" do
         context "when the position is valid" do

--- a/spec/defra_ruby/validators/token_validator_spec.rb
+++ b/spec/defra_ruby/validators/token_validator_spec.rb
@@ -14,10 +14,17 @@ module DefraRuby
   module Validators
     RSpec.describe TokenValidator, type: :model do
 
+      valid_token = Helpers::TextGenerator.random_string(24)
       invalid_token = "123456"
 
-      it_behaves_like "a validator"
-      it_behaves_like "a presence validator", TokenValidator, Test::TokenValidatable, :token
+      it_behaves_like("a validator")
+      it_behaves_like(
+        "a presence validator",
+        TokenValidator,
+        Test::TokenValidatable,
+        :token,
+        valid: valid_token
+      )
 
       describe "#validate_each" do
         context "when the token is not valid" do

--- a/spec/defra_ruby/validators/true_false_validator_spec.rb
+++ b/spec/defra_ruby/validators/true_false_validator_spec.rb
@@ -15,9 +15,16 @@ module DefraRuby
     RSpec.describe TrueFalseValidator do
 
       valid_value = %w[true false].sample
+      invalid_value = "unsure"
 
-      it_behaves_like "a validator"
-      it_behaves_like "a selection validator", TrueFalseValidator, Test::TrueFalseValidatable, :attribute, valid_value
+      it_behaves_like("a validator")
+      it_behaves_like(
+        "a selection validator",
+        TrueFalseValidator,
+        Test::TrueFalseValidatable,
+        :attribute,
+        valid: valid_value, invalid: invalid_value
+      )
     end
   end
 end

--- a/spec/support/shared_examples/validators/characters_validator.rb
+++ b/spec/support/shared_examples/validators/characters_validator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples "a characters validator" do |validator, validatable_class, attribute, invalid_input|
+RSpec.shared_examples "a characters validator" do |validator, validatable_class, attribute, values|
   it "includes CanValidateCharacters" do
     included_modules = described_class.ancestors.select { |ancestor| ancestor.instance_of?(Module) }
 
@@ -9,9 +9,13 @@ RSpec.shared_examples "a characters validator" do |validator, validatable_class,
   end
 
   describe "#validate_each" do
+    context "when the #{attribute} is valid" do
+      it_behaves_like "a valid record", validatable_class.new(values[:valid])
+    end
+
     context "when the #{attribute} is not valid" do
       context "because the #{attribute} is not correctly formatted" do
-        validatable = validatable_class.new(invalid_input)
+        validatable = validatable_class.new(values[:invalid])
         error_message = Helpers::Translator.error_message(validator, attribute, :invalid)
 
         it_behaves_like "an invalid record", validatable, attribute, error_message

--- a/spec/support/shared_examples/validators/length_validator.rb
+++ b/spec/support/shared_examples/validators/length_validator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples "a length validator" do |validator, validatable_class, attribute, invalid_input|
+RSpec.shared_examples "a length validator" do |validator, validatable_class, attribute, values|
   it "includes CanValidateLength" do
     included_modules = described_class.ancestors.select { |ancestor| ancestor.instance_of?(Module) }
 
@@ -9,9 +9,13 @@ RSpec.shared_examples "a length validator" do |validator, validatable_class, att
   end
 
   describe "#validate_each" do
+    context "when the #{attribute} is valid" do
+      it_behaves_like "a valid record", validatable_class.new(values[:valid])
+    end
+
     context "when the #{attribute} is not valid" do
       context "because the #{attribute} is too long" do
-        validatable = validatable_class.new(invalid_input)
+        validatable = validatable_class.new(values[:invalid])
         error_message = Helpers::Translator.error_message(validator, attribute, :too_long)
 
         it_behaves_like "an invalid record", validatable, attribute, error_message

--- a/spec/support/shared_examples/validators/presence_validator.rb
+++ b/spec/support/shared_examples/validators/presence_validator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples "a presence validator" do |validator, validatable_class, attribute|
+RSpec.shared_examples "a presence validator" do |validator, validatable_class, attribute, values|
   it "includes CanValidatePresence" do
     included_modules = described_class.ancestors.select { |ancestor| ancestor.instance_of?(Module) }
 
@@ -9,6 +9,10 @@ RSpec.shared_examples "a presence validator" do |validator, validatable_class, a
   end
 
   describe "#validate_each" do
+    context "when the #{attribute} is valid" do
+      it_behaves_like "a valid record", validatable_class.new(values[:valid])
+    end
+
     context "when the #{attribute} is not valid" do
       context "because the #{attribute} is not present" do
         validatable = validatable_class.new

--- a/spec/support/shared_examples/validators/selection_validator.rb
+++ b/spec/support/shared_examples/validators/selection_validator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples "a selection validator" do |validator, validatable_class, attribute, valid_value|
+RSpec.shared_examples "a selection validator" do |validator, validatable_class, attribute, values|
   it "includes CanValidateSelection" do
     included_modules = described_class.ancestors.select { |ancestor| ancestor.instance_of?(Module) }
 
@@ -10,7 +10,7 @@ RSpec.shared_examples "a selection validator" do |validator, validatable_class, 
 
   describe "#validate_each" do
     context "when the #{attribute} is valid" do
-      it_behaves_like "a valid record", validatable_class.new(valid_value)
+      it_behaves_like "a valid record", validatable_class.new(values[:valid])
     end
 
     context "when the #{attribute} is not valid" do
@@ -22,7 +22,7 @@ RSpec.shared_examples "a selection validator" do |validator, validatable_class, 
       end
 
       context "because the #{attribute} is not from an approved list" do
-        validatable = validatable_class.new("unexpected_#{attribute}")
+        validatable = validatable_class.new(values[:invalid])
         error_message = Helpers::Translator.error_message(validator, attribute, :inclusion)
 
         it_behaves_like "an invalid record", validatable, attribute, error_message


### PR DESCRIPTION
On review we started to get a little concerned that not all validators are being tested that they validate!

So this change is the result of a review of each validator spec and associated concern specs (shared examples).

Key changes are

- ensuring each shared example includes a test for valid input as well as invalid input
- where a validation is not covered by a concern, ensuring the main spec has a test that covers valid input
- implementing a consistant API across the shared examples whereby the main spec passes in both the valid and invalid values to be used
- making `max_length` a class accessible constant on `PositionValidator` so it can be used in the the spec rather than a magic number