### PR TITLE
Remove dev dependency rubocop

### DIFF
--- a/defra_ruby_validators.gemspec
+++ b/defra_ruby_validators.gemspec
@@ -52,7 +52,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rubocop"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "vcr", "~> 4.0"
   spec.add_development_dependency "webmock", "~> 3.4"


### PR DESCRIPTION
[defra_ruby_style](https://github.com/DEFRA/defra-ruby-style) is our own gem which wraps rubocop and provides a standard config for it. With it already declared as a dev dependency not sure why rubocop has also been listed separately.

Just an oversight, but this change resolves it by removing rubocop from the gemspec.