### PR TITLE
Ensure we define attributes in concern methods

### DIFF
--- a/lib/defra_ruby/validators/email_validator.rb
+++ b/lib/defra_ruby/validators/email_validator.rb
@@ -8,7 +8,7 @@ module DefraRuby
       include CanValidatePresence
 
       def validate_each(record, attribute, value)
-        return false unless value_is_present?(record, attribute, value)
+        return false unless value_is_present?(record, :email, value)
 
         valid_format?(record, attribute, value)
       end

--- a/lib/defra_ruby/validators/grid_reference_validator.rb
+++ b/lib/defra_ruby/validators/grid_reference_validator.rb
@@ -8,7 +8,7 @@ module DefraRuby
       include CanValidatePresence
 
       def validate_each(record, attribute, value)
-        return false unless value_is_present?(record, attribute, value)
+        return false unless value_is_present?(record, :grid_reference, value)
         return false unless valid_format?(record, attribute, value)
 
         valid_coordinate?(record, attribute, value)

--- a/lib/defra_ruby/validators/position_validator.rb
+++ b/lib/defra_ruby/validators/position_validator.rb
@@ -8,10 +8,10 @@ module DefraRuby
 
       MAX_LENGTH = 70
 
-      def validate_each(record, attribute, value)
+      def validate_each(record, _attribute, value)
         # Position is an optional field so its immediately valid if it's blank
         return true if value.blank?
-        return false unless value_has_no_invalid_characters?(record, attribute, value)
+        return false unless value_has_no_invalid_characters?(record, :position, value)
 
         value_is_not_too_long?(record, :position, value, MAX_LENGTH)
         value_has_no_invalid_characters?(record, :position, value)

--- a/lib/defra_ruby/validators/token_validator.rb
+++ b/lib/defra_ruby/validators/token_validator.rb
@@ -6,7 +6,7 @@ module DefraRuby
       include CanValidatePresence
 
       def validate_each(record, attribute, value)
-        return false unless value_is_present?(record, attribute, value)
+        return false unless value_is_present?(record, :token, value)
 
         valid_format?(record, attribute, value)
       end


### PR DESCRIPTION
For validators that share a concern, we have to define the attribute incase there is an error. If there is the concern needs to know the attrubute so it can then use it to locate the correct error message via the locales.

We have made it clear in the README what attribute to define for each validator, but we want to be sure we are specifying the correct one in validators with a concern.

So this change swaps out `attribute` for `:my_attribute_name` where it is needed.