### PR TITLE
Enable the gem to use custom validation error messages

### DIFF
--- a/lib/defra_ruby/validators/base_validator.rb
+++ b/lib/defra_ruby/validators/base_validator.rb
@@ -7,7 +7,7 @@ module DefraRuby
       protected
 
       def error_message(attribute, error)
-        I18n.t("defra_ruby.validators.#{class_name}.#{attribute}.#{error}")
+        options[:message] || I18n.t("defra_ruby.validators.#{class_name}.#{attribute}.#{error}")
       end
 
       private

--- a/spec/cassettes/company_no_inactive.yml
+++ b/spec/cassettes/company_no_inactive.yml
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin18.2.0 x86_64) ruby/2.4.2p198
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.2p198
       Host:
       - api.companieshouse.gov.uk
       Authorization:
@@ -22,6 +22,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Date:
+      - Tue, 06 Aug 2019 09:09:38 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '979'
+      Connection:
+      - keep-alive
       Access-Control-Allow-Credentials:
       - 'true'
       Access-Control-Allow-Headers:
@@ -36,26 +44,18 @@ http_interactions:
       - '3600'
       Cache-Control:
       - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 21 Jun 2019 19:49:21 GMT
       Pragma:
       - no-cache
-      Server:
-      - CompaniesHouse
       X-Ratelimit-Limit:
       - '600'
       X-Ratelimit-Remain:
-      - '599'
+      - '595'
       X-Ratelimit-Reset:
-      - '1561146861'
+      - '1565082737'
       X-Ratelimit-Window:
       - 5m
-      Content-Length:
-      - '979'
-      Connection:
-      - keep-alive
+      Server:
+      - CompaniesHouse
     body:
       encoding: UTF-8
       string: '{"sic_codes":["82990"],"company_number":"07281919","has_been_liquidated":false,"accounts":{"last_accounts":{"made_up_to":"2013-06-30","type":"total-exemption-small"},"accounting_reference_date":{"day":"30","month":"06"}},"last_full_members_list_date":"2014-06-11","status":"active","type":"ltd","date_of_creation":"2010-06-11","registered_office_address":{"postal_code":"HA8
@@ -63,5 +63,5 @@ http_interactions:
         Elizabeth House","address_line_2":"54-58 High Street"},"undeliverable_registered_office_address":false,"company_name":"DIRECT
         SKIPS UK LTD","annual_return":{"last_made_up_to":"2014-06-11"},"jurisdiction":"england-wales","etag":"1cdef5bc2a020b3e9003b086033b64b78bcb28f6","company_status":"dissolved","has_insolvency_history":false,"has_charges":false,"links":{"self":"/company/07281919","filing_history":"/company/07281919/filing-history","officers":"/company/07281919/officers"},"date_of_cessation":"2016-01-05","can_file":false}'
     http_version: 
-  recorded_at: Fri, 21 Jun 2019 19:49:20 GMT
+  recorded_at: Tue, 06 Aug 2019 09:09:36 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/company_no_not_found.yml
+++ b/spec/cassettes/company_no_not_found.yml
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin18.2.0 x86_64) ruby/2.4.2p198
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.2p198
       Host:
       - api.companieshouse.gov.uk
       Authorization:
@@ -22,6 +22,14 @@ http_interactions:
       code: 404
       message: Not Found
     headers:
+      Date:
+      - Tue, 06 Aug 2019 09:09:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '70'
+      Connection:
+      - keep-alive
       Access-Control-Allow-Credentials:
       - 'true'
       Access-Control-Allow-Headers:
@@ -36,29 +44,21 @@ http_interactions:
       - '3600'
       Cache-Control:
       - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 21 Jun 2019 19:49:21 GMT
       Pragma:
       - no-cache
-      Server:
-      - CompaniesHouse
       X-Ratelimit-Limit:
       - '600'
       X-Ratelimit-Remain:
-      - '597'
+      - '593'
       X-Ratelimit-Reset:
-      - '1561146861'
+      - '1565082737'
       X-Ratelimit-Window:
       - 5m
-      Content-Length:
-      - '70'
-      Connection:
-      - keep-alive
+      Server:
+      - CompaniesHouse
     body:
       encoding: UTF-8
       string: '{"errors":[{"error":"company-profile-not-found","type":"ch:service"}]}'
     http_version: 
-  recorded_at: Fri, 21 Jun 2019 19:49:21 GMT
+  recorded_at: Tue, 06 Aug 2019 09:09:36 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/company_no_valid.yml
+++ b/spec/cassettes/company_no_valid.yml
@@ -12,7 +12,7 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin18.2.0 x86_64) ruby/2.4.2p198
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.2p198
       Host:
       - api.companieshouse.gov.uk
       Authorization:
@@ -22,6 +22,14 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Date:
+      - Tue, 06 Aug 2019 09:09:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1178'
+      Connection:
+      - keep-alive
       Access-Control-Allow-Credentials:
       - 'true'
       Access-Control-Allow-Headers:
@@ -36,30 +44,22 @@ http_interactions:
       - '3600'
       Cache-Control:
       - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 21 Jun 2019 19:49:21 GMT
       Pragma:
       - no-cache
-      Server:
-      - CompaniesHouse
       X-Ratelimit-Limit:
       - '600'
       X-Ratelimit-Remain:
-      - '598'
+      - '594'
       X-Ratelimit-Reset:
-      - '1561146861'
+      - '1565082737'
       X-Ratelimit-Window:
       - 5m
-      Content-Length:
-      - '1178'
-      Connection:
-      - keep-alive
+      Server:
+      - CompaniesHouse
     body:
       encoding: UTF-8
       string: '{"type":"ltd","company_name":"0800 WASTE LTD.","has_insolvency_history":false,"accounts":{"next_due":"2019-09-30","next_made_up_to":"2018-12-31","next_accounts":{"overdue":false,"period_start_on":"2018-01-01","due_on":"2019-09-30","period_end_on":"2018-12-31"},"accounting_reference_date":{"month":"12","day":"31"},"last_accounts":{"period_end_on":"2017-12-31","period_start_on":"2017-01-01","made_up_to":"2017-12-31"},"overdue":false},"undeliverable_registered_office_address":false,"etag":"0ec9d00cab0ffee2ef1f5d59f4f714fa5b1618f5","company_number":"09360070","registered_office_address":{"postal_code":"SM3
         9ND","locality":"Sutton","region":"Surrey","address_line_1":"21 Haslam Avenue"},"jurisdiction":"england-wales","date_of_creation":"2014-12-18","company_status":"active","has_charges":false,"sic_codes":["38110"],"last_full_members_list_date":"2015-12-18","confirmation_statement":{"overdue":false,"next_made_up_to":"2020-01-23","last_made_up_to":"2019-01-23","next_due":"2020-02-06"},"links":{"self":"/company/09360070","filing_history":"/company/09360070/filing-history","officers":"/company/09360070/officers"},"registered_office_is_in_dispute":false,"can_file":true}'
     http_version: 
-  recorded_at: Fri, 21 Jun 2019 19:49:20 GMT
+  recorded_at: Tue, 06 Aug 2019 09:09:36 GMT
 recorded_with: VCR 4.0.0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,10 @@ require "bundler/setup"
 # This is as per its docs https://github.com/colszowka/simplecov#getting-started
 require "./spec/support/simplecov"
 
+# Load env vars from a text file. This must be done before we load the other
+# support files as some of them rely on the env vars being set.
+require "dotenv/load"
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/spec/support/dotenv.rb
+++ b/spec/support/dotenv.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-# Load env vars from a text file
-require "dotenv/load"

--- a/spec/support/shared_examples/validators/invalid_record.rb
+++ b/spec/support/shared_examples/validators/invalid_record.rb
@@ -15,4 +15,14 @@ RSpec.shared_examples "an invalid record" do |validatable, attribute, error_mess
     expect(error_message).to_not include("translation missing:")
     expect(validatable.errors[attribute]).to eq([error_message])
   end
+
+  context "when there is a custom error message" do
+    let(:custom_message) { "something is wrong (in a customised way)" }
+    before { allow_any_instance_of(DefraRuby::Validators::BaseValidator).to receive(:options).and_return(message: custom_message) }
+
+    it "uses the custom message instead of the default" do
+      validatable.valid?
+      expect(validatable.errors[attribute]).to eq([custom_message])
+    end
+  end
 end


### PR DESCRIPTION
This is to support https://eaflood.atlassian.net/browse/RUBY-493

Each validator in the gem comes with I18n error messages. However, in some cases, we'd like to be able to override these with a custom message.