### PR TITLE
TrueFalseValidator uses correct attribute

### DIFF
--- a/lib/defra_ruby/validators/true_false_validator.rb
+++ b/lib/defra_ruby/validators/true_false_validator.rb
@@ -5,10 +5,10 @@ module DefraRuby
     class TrueFalseValidator < BaseValidator
       include CanValidateSelection
 
-      def validate_each(record, _attribute, value)
+      def validate_each(record, attribute, value)
         valid_options = %w[true false]
 
-        value_is_included?(record, :attribute, value, valid_options)
+        value_is_included?(record, attribute, value, valid_options)
       end
     end
   end


### PR DESCRIPTION
Spotted that the TrueFalseValidator was assigning errors to a key called :attribute instead of the actual attribute name. This change fixes that issue.