### PR TITLE
Enable gem to receive multiple custom error messages

### DIFF
--- a/lib/defra_ruby/validators/base_validator.rb
+++ b/lib/defra_ruby/validators/base_validator.rb
@@ -7,7 +7,11 @@ module DefraRuby
       protected
 
       def error_message(attribute, error)
-        options[:message] || I18n.t("defra_ruby.validators.#{class_name}.#{attribute}.#{error}")
+        if options[:messages] && options[:messages][error]
+          options[:messages][error]
+        else
+          I18n.t("defra_ruby.validators.#{class_name}.#{attribute}.#{error}")
+        end
       end
 
       private

--- a/spec/defra_ruby/validators/companies_house_number_validator_spec.rb
+++ b/spec/defra_ruby/validators/companies_house_number_validator_spec.rb
@@ -43,7 +43,11 @@ module DefraRuby
               :blank
             )
 
-            it_behaves_like "an invalid record", validatable, :company_no, error_message
+            it_behaves_like "an invalid record",
+                            validatable: validatable,
+                            attribute: :company_no,
+                            error: :blank,
+                            error_message: error_message
           end
 
           context "because the format is wrong" do
@@ -54,7 +58,11 @@ module DefraRuby
               :invalid
             )
 
-            it_behaves_like "an invalid record", validatable, :company_no, error_message
+            it_behaves_like "an invalid record",
+                            validatable: validatable,
+                            attribute: :company_no,
+                            error: :invalid,
+                            error_message: error_message
           end
 
           context "because it's not found on companies house" do
@@ -69,7 +77,11 @@ module DefraRuby
               :not_found
             )
 
-            it_behaves_like "an invalid record", validatable, :company_no, error_message
+            it_behaves_like "an invalid record",
+                            validatable: validatable,
+                            attribute: :company_no,
+                            error: :not_found,
+                            error_message: error_message
           end
 
           context "because it's not 'active' on companies house" do
@@ -84,7 +96,11 @@ module DefraRuby
               :inactive
             )
 
-            it_behaves_like "an invalid record", validatable, :company_no, error_message
+            it_behaves_like "an invalid record",
+                            validatable: validatable,
+                            attribute: :company_no,
+                            error: :inactive,
+                            error_message: error_message
           end
         end
 
@@ -100,7 +116,11 @@ module DefraRuby
             :error
           )
 
-          it_behaves_like "an invalid record", validatable, :company_no, error_message
+          it_behaves_like "an invalid record",
+                          validatable: validatable,
+                          attribute: :company_no,
+                          error: :error,
+                          error_message: error_message
         end
       end
     end

--- a/spec/defra_ruby/validators/email_validator_spec.rb
+++ b/spec/defra_ruby/validators/email_validator_spec.rb
@@ -33,7 +33,11 @@ module DefraRuby
 
             error_message = Helpers::Translator.error_message(EmailValidator, :email, :invalid_format)
 
-            it_behaves_like "an invalid record", validatable, :email, error_message
+            it_behaves_like "an invalid record",
+                            validatable: validatable,
+                            attribute: :email,
+                            error: :invalid_format,
+                            error_message: error_message
           end
         end
       end

--- a/spec/defra_ruby/validators/grid_reference_validator_spec.rb
+++ b/spec/defra_ruby/validators/grid_reference_validator_spec.rb
@@ -33,14 +33,22 @@ module DefraRuby
             validatable = Test::GridReferenceValidatable.new(invalid_grid_reference)
             error_message = Helpers::Translator.error_message(GridReferenceValidator, :grid_reference, :wrong_format)
 
-            it_behaves_like "an invalid record", validatable, :grid_reference, error_message
+            it_behaves_like "an invalid record",
+                            validatable: validatable,
+                            attribute: :grid_reference,
+                            error: :wrong_format,
+                            error_message: error_message
           end
 
           context "because the grid reference is not a coordinate" do
             validatable = Test::GridReferenceValidatable.new(non_coordinate_grid_reference)
             error_message = Helpers::Translator.error_message(GridReferenceValidator, :grid_reference, :invalid)
 
-            it_behaves_like "an invalid record", validatable, :grid_reference, error_message
+            it_behaves_like "an invalid record",
+                            validatable: validatable,
+                            attribute: :grid_reference,
+                            error: :invalid,
+                            error_message: error_message
           end
         end
       end

--- a/spec/defra_ruby/validators/phone_number_validator_spec.rb
+++ b/spec/defra_ruby/validators/phone_number_validator_spec.rb
@@ -46,7 +46,11 @@ module DefraRuby
             validatable = Test::PhoneNumberValidatable.new(invalid_number)
             error_message = Helpers::Translator.error_message(PhoneNumberValidator, :phone_number, :invalid_format)
 
-            it_behaves_like "an invalid record", validatable, :phone_number, error_message
+            it_behaves_like "an invalid record",
+                            validatable: validatable,
+                            attribute: :phone_number,
+                            error: :invalid_format,
+                            error_message: error_message
           end
         end
       end

--- a/spec/defra_ruby/validators/token_validator_spec.rb
+++ b/spec/defra_ruby/validators/token_validator_spec.rb
@@ -32,7 +32,11 @@ module DefraRuby
             validatable = Test::TokenValidatable.new(invalid_token)
             error_message = Helpers::Translator.error_message(TokenValidator, :token, :invalid_format)
 
-            it_behaves_like "an invalid record", validatable, :token, error_message
+            it_behaves_like "an invalid record",
+                            validatable: validatable,
+                            attribute: :token,
+                            error: :invalid_format,
+                            error_message: error_message
           end
         end
       end

--- a/spec/support/shared_examples/validators/characters_validator.rb
+++ b/spec/support/shared_examples/validators/characters_validator.rb
@@ -18,7 +18,11 @@ RSpec.shared_examples "a characters validator" do |validator, validatable_class,
         validatable = validatable_class.new(values[:invalid])
         error_message = Helpers::Translator.error_message(validator, attribute, :invalid)
 
-        it_behaves_like "an invalid record", validatable, attribute, error_message
+        it_behaves_like "an invalid record",
+                        validatable: validatable,
+                        attribute: attribute,
+                        error: :invalid,
+                        error_message: error_message
       end
     end
   end

--- a/spec/support/shared_examples/validators/invalid_record.rb
+++ b/spec/support/shared_examples/validators/invalid_record.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples "an invalid record" do |validatable, attribute, error_message|
+RSpec.shared_examples "an invalid record" do |validatable:, attribute:, error:, error_message:|
   it "confirms the object is invalid" do
     expect(validatable).to_not be_valid
   end
@@ -16,9 +16,10 @@ RSpec.shared_examples "an invalid record" do |validatable, attribute, error_mess
     expect(validatable.errors[attribute]).to eq([error_message])
   end
 
-  context "when there is a custom error message" do
+  context "when there are custom error messages" do
     let(:custom_message) { "something is wrong (in a customised way)" }
-    before { allow_any_instance_of(DefraRuby::Validators::BaseValidator).to receive(:options).and_return(message: custom_message) }
+    let(:messages) { { error => custom_message } }
+    before { allow_any_instance_of(DefraRuby::Validators::BaseValidator).to receive(:options).and_return(messages: messages) }
 
     it "uses the custom message instead of the default" do
       validatable.valid?

--- a/spec/support/shared_examples/validators/length_validator.rb
+++ b/spec/support/shared_examples/validators/length_validator.rb
@@ -18,7 +18,11 @@ RSpec.shared_examples "a length validator" do |validator, validatable_class, att
         validatable = validatable_class.new(values[:invalid])
         error_message = Helpers::Translator.error_message(validator, attribute, :too_long)
 
-        it_behaves_like "an invalid record", validatable, attribute, error_message
+        it_behaves_like "an invalid record",
+                        validatable: validatable,
+                        attribute: attribute,
+                        error: :too_long,
+                        error_message: error_message
       end
     end
   end

--- a/spec/support/shared_examples/validators/presence_validator.rb
+++ b/spec/support/shared_examples/validators/presence_validator.rb
@@ -18,7 +18,11 @@ RSpec.shared_examples "a presence validator" do |validator, validatable_class, a
         validatable = validatable_class.new
         error_message = Helpers::Translator.error_message(validator, attribute, :blank)
 
-        it_behaves_like "an invalid record", validatable, attribute, error_message
+        it_behaves_like "an invalid record",
+                        validatable: validatable,
+                        attribute: attribute,
+                        error: :blank,
+                        error_message: error_message
       end
     end
   end

--- a/spec/support/shared_examples/validators/selection_validator.rb
+++ b/spec/support/shared_examples/validators/selection_validator.rb
@@ -18,14 +18,22 @@ RSpec.shared_examples "a selection validator" do |validator, validatable_class, 
         validatable = validatable_class.new
         error_message = Helpers::Translator.error_message(validator, attribute, :inclusion)
 
-        it_behaves_like "an invalid record", validatable, attribute, error_message
+        it_behaves_like "an invalid record",
+                        validatable: validatable,
+                        attribute: attribute,
+                        error: :inclusion,
+                        error_message: error_message
       end
 
       context "because the #{attribute} is not from an approved list" do
         validatable = validatable_class.new(values[:invalid])
         error_message = Helpers::Translator.error_message(validator, attribute, :inclusion)
 
-        it_behaves_like "an invalid record", validatable, attribute, error_message
+        it_behaves_like "an invalid record",
+                        validatable: validatable,
+                        attribute: attribute,
+                        error: :inclusion,
+                        error_message: error_message
       end
     end
   end


### PR DESCRIPTION
Previously the gem was set up to receive a custom error message for a validator. However, some validators produce different errors depending on the result - for example, a missing value produces one error while a too-long value produces another. We want to be able to provide custom errors for all circumstances.

This requires some refactoring of the tests as well.