### PR TITLE
Standardise invalid format errors

### DIFF
--- a/config/locales/defra_ruby/validators/companies_house_number_validator/en.yml
+++ b/config/locales/defra_ruby/validators/companies_house_number_validator/en.yml
@@ -4,7 +4,7 @@ en:
       CompaniesHouseNumberValidator:
         company_no:
           blank: Enter a company registration number
-          invalid: "Enter a valid number - it should have 8 digits, or 2 letters followed by 6 digits, or 2 letters followed by 5 digits and another letter. If your number has only 7 digits, enter it with a zero at the start."
+          invalid_format: "Enter a valid number - it should have 8 digits, or 2 letters followed by 6 digits, or 2 letters followed by 5 digits and another letter. If your number has only 7 digits, enter it with a zero at the start."
           not_found: Companies House couldn't find a company with this number
           inactive: Your company must be registered as an active company
           error: There was an error connecting with Companies House. Hopefully this is a one off and will work if you try again.

--- a/config/locales/defra_ruby/validators/grid_reference_validator/en.yml
+++ b/config/locales/defra_ruby/validators/grid_reference_validator/en.yml
@@ -4,5 +4,5 @@ en:
       GridReferenceValidator:
         grid_reference:
           blank: Enter a grid reference
-          wrong_format: The grid reference should have 2 letters and 10 digits
+          invalid_format: The grid reference should have 2 letters and 10 digits
           invalid: The grid reference is not a valid coordinate

--- a/config/locales/defra_ruby/validators/position_validator/en.yml
+++ b/config/locales/defra_ruby/validators/position_validator/en.yml
@@ -3,5 +3,5 @@ en:
     validators:
       PositionValidator:
         position:
-          invalid: "The position must contain only letters, spaces, commas, full stops, hyphens and apostrophes"
+          invalid_format: "The position must contain only letters, spaces, commas, full stops, hyphens and apostrophes"
           too_long: "The position must have no more than 70 characters"

--- a/lib/defra_ruby/validators/companies_house_number_validator.rb
+++ b/lib/defra_ruby/validators/companies_house_number_validator.rb
@@ -32,7 +32,7 @@ module DefraRuby
       def format_is_valid?(record, attribute, value)
         return true if value.match?(VALID_COMPANIES_HOUSE_REGISTRATION_NUMBER_REGEX)
 
-        record.errors[attribute] << error_message(:company_no, :invalid)
+        record.errors[attribute] << error_message(:company_no, :invalid_format)
         false
       end
 

--- a/lib/defra_ruby/validators/concerns/can_validate_characters.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_characters.rb
@@ -10,7 +10,7 @@ module DefraRuby
         # Name fields must contain only letters, spaces, commas, full stops, hyphens and apostrophes
         return true if value.match?(/\A[-a-z\s,.']+\z/i)
 
-        record.errors[attribute] << error_message(attribute, :invalid)
+        record.errors[attribute] << error_message(attribute, :invalid_format)
         false
       end
 

--- a/lib/defra_ruby/validators/grid_reference_validator.rb
+++ b/lib/defra_ruby/validators/grid_reference_validator.rb
@@ -22,7 +22,7 @@ module DefraRuby
       def valid_format?(record, attribute, value)
         return true if value.match?(/\A#{grid_reference_pattern}\z/)
 
-        record.errors[attribute] << error_message(:grid_reference, :wrong_format)
+        record.errors[attribute] << error_message(:grid_reference, :invalid_format)
         false
       end
 

--- a/spec/defra_ruby/validators/companies_house_number_validator_spec.rb
+++ b/spec/defra_ruby/validators/companies_house_number_validator_spec.rb
@@ -55,13 +55,13 @@ module DefraRuby
             error_message = Helpers::Translator.error_message(
               CompaniesHouseNumberValidator,
               :company_no,
-              :invalid
+              :invalid_format
             )
 
             it_behaves_like "an invalid record",
                             validatable: validatable,
                             attribute: :company_no,
-                            error: :invalid,
+                            error: :invalid_format,
                             error_message: error_message
           end
 

--- a/spec/defra_ruby/validators/grid_reference_validator_spec.rb
+++ b/spec/defra_ruby/validators/grid_reference_validator_spec.rb
@@ -31,12 +31,12 @@ module DefraRuby
         context "when the grid reference is not valid" do
           context "because the grid reference is not correctly formatted" do
             validatable = Test::GridReferenceValidatable.new(invalid_grid_reference)
-            error_message = Helpers::Translator.error_message(GridReferenceValidator, :grid_reference, :wrong_format)
+            error_message = Helpers::Translator.error_message(GridReferenceValidator, :grid_reference, :invalid_format)
 
             it_behaves_like "an invalid record",
                             validatable: validatable,
                             attribute: :grid_reference,
-                            error: :wrong_format,
+                            error: :invalid_format,
                             error_message: error_message
           end
 

--- a/spec/support/shared_examples/validators/characters_validator.rb
+++ b/spec/support/shared_examples/validators/characters_validator.rb
@@ -16,12 +16,12 @@ RSpec.shared_examples "a characters validator" do |validator, validatable_class,
     context "when the #{attribute} is not valid" do
       context "because the #{attribute} is not correctly formatted" do
         validatable = validatable_class.new(values[:invalid])
-        error_message = Helpers::Translator.error_message(validator, attribute, :invalid)
+        error_message = Helpers::Translator.error_message(validator, attribute, :invalid_format)
 
         it_behaves_like "an invalid record",
                         validatable: validatable,
                         attribute: attribute,
-                        error: :invalid,
+                        error: :invalid_format,
                         error_message: error_message
       end
     end


### PR DESCRIPTION
We have a lot of errors which are down to invalid formats. However, the error we were returning was inconsistent - `invalid`, `wrong_format`, etc. This PR standardises them all to `invalid_format`.