### PR TITLE
Add option to validate 'overseas' as business type

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Add it to your model or form object using
 validates :business_type, "defra_ruby/validators/business_type": true
 ```
 
+If you want to include `overseas` in the accepted business types, you can enable this in the options:
+
+```ruby
+validates :business_type, "defra_ruby/validators/business_type": { allow_overseas: true }
+```
+
 ### Companies House number
 
 This validator checks the company registration number provided. Specifically it first checks that it matches a known format. All registration numbers are 8 characters long but can be formatted in the following ways.

--- a/lib/defra_ruby/validators/business_type_validator.rb
+++ b/lib/defra_ruby/validators/business_type_validator.rb
@@ -6,9 +6,20 @@ module DefraRuby
       include CanValidateSelection
 
       def validate_each(record, _attribute, value)
-        valid_options = %w[soleTrader limitedCompany partnership limitedLiabilityPartnership localAuthority charity]
-
         value_is_included?(record, :business_type, value, valid_options)
+      end
+
+      private
+
+      def valid_options
+        options = %w[soleTrader limitedCompany partnership limitedLiabilityPartnership localAuthority charity]
+        options.push("overseas") if allow_overseas?
+
+        options
+      end
+
+      def allow_overseas?
+        options[:allow_overseas] == true
       end
     end
   end

--- a/spec/defra_ruby/validators/business_type_validator_spec.rb
+++ b/spec/defra_ruby/validators/business_type_validator_spec.rb
@@ -25,6 +25,32 @@ module DefraRuby
         :business_type,
         valid: valid_type, invalid: invalid_type
       )
+
+      context "when the value is overseas" do
+        validatable = Test::BusinessTypeValidatable.new("overseas")
+
+        context "when overseas_allowed is enabled" do
+          before do
+            allow_any_instance_of(DefraRuby::Validators::BaseValidator).to receive(:options).and_return(allow_overseas: true)
+          end
+
+          it_behaves_like "a valid record", validatable
+        end
+
+        context "when overseas_allowed is not enabled" do
+          before do
+            allow_any_instance_of(DefraRuby::Validators::BaseValidator).to receive(:options).and_return({})
+          end
+
+          error_message = Helpers::Translator.error_message(BusinessTypeValidator, :business_type, :inclusion)
+
+          it_behaves_like "an invalid record",
+                          validatable: validatable,
+                          attribute: :business_type,
+                          error: :inclusion,
+                          error_message: error_message
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This is required if we're going to use this validator in the waste-carriers-engine. However, the default is to not include "overseas".