### PR TITLE
Add option to validate 'overseas' as location

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ Add it to your model or form object using
 validates :location, "defra_ruby/validators/location": true
 ```
 
+If you want to include `overseas` in the accepted locations, you can enable this in the options:
+
+ ```ruby
+validates :location, "defra_ruby/validators/location": { allow_overseas: true }
+```
+
 ### Phone number
 
 This validator checks the value is present, is not too long (15 is th maximum length for any phone number), and is in the correct format as per [E.164](https://en.wikipedia.org/wiki/E.164) (we use [phonelib](https://github.com/daddyz/phonelib) to check the format).

--- a/lib/defra_ruby/validators/location_validator.rb
+++ b/lib/defra_ruby/validators/location_validator.rb
@@ -6,9 +6,20 @@ module DefraRuby
       include CanValidateSelection
 
       def validate_each(record, _attribute, value)
-        valid_options = %w[england northern_ireland scotland wales]
-
         value_is_included?(record, :location, value, valid_options)
+      end
+
+      private
+
+      def valid_options
+        options = %w[england northern_ireland scotland wales]
+        options.push("overseas") if allow_overseas?
+
+        options
+      end
+
+      def allow_overseas?
+        options[:allow_overseas] == true
       end
     end
   end

--- a/spec/defra_ruby/validators/location_validator_spec.rb
+++ b/spec/defra_ruby/validators/location_validator_spec.rb
@@ -25,6 +25,32 @@ module DefraRuby
         :location,
         valid: valid_location, invalid: invalid_location
       )
+
+      context "when the value is overseas" do
+        validatable = Test::LocationValidatable.new("overseas")
+
+        context "when overseas_allowed is enabled" do
+          before do
+            allow_any_instance_of(DefraRuby::Validators::BaseValidator).to receive(:options).and_return(allow_overseas: true)
+          end
+
+          it_behaves_like "a valid record", validatable
+        end
+
+        context "when overseas_allowed is not enabled" do
+          before do
+            allow_any_instance_of(DefraRuby::Validators::BaseValidator).to receive(:options).and_return({})
+          end
+
+          error_message = Helpers::Translator.error_message(LocationValidator, :location, :inclusion)
+
+          it_behaves_like "an invalid record",
+                          validatable: validatable,
+                          attribute: :location,
+                          error: :inclusion,
+                          error_message: error_message
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This is required if we're going to use this validator in the waste-carriers-engine. However, the default is to not include "overseas".