### PR TITLE
Use attribute correct name during validation

### DIFF
--- a/lib/defra_ruby/validators/business_type_validator.rb
+++ b/lib/defra_ruby/validators/business_type_validator.rb
@@ -5,8 +5,8 @@ module DefraRuby
     class BusinessTypeValidator < BaseValidator
       include CanValidateSelection
 
-      def validate_each(record, _attribute, value)
-        value_is_included?(record, :business_type, value, valid_options)
+      def validate_each(record, attribute, value)
+        value_is_included?(record, attribute, value, valid_options)
       end
 
       private

--- a/lib/defra_ruby/validators/email_validator.rb
+++ b/lib/defra_ruby/validators/email_validator.rb
@@ -8,7 +8,7 @@ module DefraRuby
       include CanValidatePresence
 
       def validate_each(record, attribute, value)
-        return false unless value_is_present?(record, :email, value)
+        return false unless value_is_present?(record, attribute, value)
 
         valid_format?(record, attribute, value)
       end

--- a/lib/defra_ruby/validators/grid_reference_validator.rb
+++ b/lib/defra_ruby/validators/grid_reference_validator.rb
@@ -8,7 +8,7 @@ module DefraRuby
       include CanValidatePresence
 
       def validate_each(record, attribute, value)
-        return false unless value_is_present?(record, :grid_reference, value)
+        return false unless value_is_present?(record, attribute, value)
         return false unless valid_format?(record, attribute, value)
 
         valid_coordinate?(record, attribute, value)

--- a/lib/defra_ruby/validators/location_validator.rb
+++ b/lib/defra_ruby/validators/location_validator.rb
@@ -5,8 +5,8 @@ module DefraRuby
     class LocationValidator < BaseValidator
       include CanValidateSelection
 
-      def validate_each(record, _attribute, value)
-        value_is_included?(record, :location, value, valid_options)
+      def validate_each(record, attribute, value)
+        value_is_included?(record, attribute, value, valid_options)
       end
 
       private

--- a/lib/defra_ruby/validators/phone_number_validator.rb
+++ b/lib/defra_ruby/validators/phone_number_validator.rb
@@ -11,8 +11,8 @@ module DefraRuby
       MAX_LENGTH = 15
 
       def validate_each(record, attribute, value)
-        return false unless value_is_present?(record, :phone_number, value)
-        return false unless value_is_not_too_long?(record, :phone_number, value, MAX_LENGTH)
+        return false unless value_is_present?(record, attribute, value)
+        return false unless value_is_not_too_long?(record, attribute, value, MAX_LENGTH)
 
         valid_format?(record, attribute, value)
       end

--- a/lib/defra_ruby/validators/position_validator.rb
+++ b/lib/defra_ruby/validators/position_validator.rb
@@ -8,13 +8,13 @@ module DefraRuby
 
       MAX_LENGTH = 70
 
-      def validate_each(record, _attribute, value)
+      def validate_each(record, attribute, value)
         # Position is an optional field so its immediately valid if it's blank
         return true if value.blank?
-        return false unless value_has_no_invalid_characters?(record, :position, value)
+        return false unless value_has_no_invalid_characters?(record, attribute, value)
 
-        value_is_not_too_long?(record, :position, value, MAX_LENGTH)
-        value_has_no_invalid_characters?(record, :position, value)
+        value_is_not_too_long?(record, attribute, value, MAX_LENGTH)
+        value_has_no_invalid_characters?(record, attribute, value)
       end
 
     end

--- a/lib/defra_ruby/validators/token_validator.rb
+++ b/lib/defra_ruby/validators/token_validator.rb
@@ -6,7 +6,7 @@ module DefraRuby
       include CanValidatePresence
 
       def validate_each(record, attribute, value)
-        return false unless value_is_present?(record, :token, value)
+        return false unless value_is_present?(record, attribute, value)
 
         valid_format?(record, attribute, value)
       end


### PR DESCRIPTION
As part of some renaming work going on in the WEX engine forms, we found out that the validator gem was hard-coding attribute names in some cases.
This fix will make sure that the error is added to the record with the correct attribute name passed by the validation code in the forms.
Specifically, we have renamed `phone_number` in the applicant phone form to become `applicant_phone` in line with the transient registration attributes. Our engine tests on the validations shown that the error was coming through as `phone_number` even if the attribute sent to validate was `applicant_phone`. 