### PR TITLE
Make error messages attribute agnostic

### DIFF
--- a/config/locales/defra_ruby/validators/business_type_validator/en.yml
+++ b/config/locales/defra_ruby/validators/business_type_validator/en.yml
@@ -2,5 +2,4 @@ en:
   defra_ruby:
     validators:
       BusinessTypeValidator:
-        attribute:
-          inclusion: "You must answer this question"
+        inclusion: "You must answer this question"

--- a/config/locales/defra_ruby/validators/business_type_validator/en.yml
+++ b/config/locales/defra_ruby/validators/business_type_validator/en.yml
@@ -2,5 +2,5 @@ en:
   defra_ruby:
     validators:
       BusinessTypeValidator:
-        business_type:
+        attribute:
           inclusion: "You must answer this question"

--- a/config/locales/defra_ruby/validators/companies_house_number_validator/en.yml
+++ b/config/locales/defra_ruby/validators/companies_house_number_validator/en.yml
@@ -2,7 +2,7 @@ en:
   defra_ruby:
     validators:
       CompaniesHouseNumberValidator:
-        company_no:
+        attribute:
           blank: Enter a company registration number
           invalid_format: "Enter a valid number - it should have 8 digits, or 2 letters followed by 6 digits, or 2 letters followed by 5 digits and another letter. If your number has only 7 digits, enter it with a zero at the start."
           not_found: Companies House couldn't find a company with this number

--- a/config/locales/defra_ruby/validators/companies_house_number_validator/en.yml
+++ b/config/locales/defra_ruby/validators/companies_house_number_validator/en.yml
@@ -2,9 +2,8 @@ en:
   defra_ruby:
     validators:
       CompaniesHouseNumberValidator:
-        attribute:
-          blank: Enter a company registration number
-          invalid_format: "Enter a valid number - it should have 8 digits, or 2 letters followed by 6 digits, or 2 letters followed by 5 digits and another letter. If your number has only 7 digits, enter it with a zero at the start."
-          not_found: Companies House couldn't find a company with this number
-          inactive: Your company must be registered as an active company
-          error: There was an error connecting with Companies House. Hopefully this is a one off and will work if you try again.
+        blank: Enter a company registration number
+        invalid_format: "Enter a valid number - it should have 8 digits, or 2 letters followed by 6 digits, or 2 letters followed by 5 digits and another letter. If your number has only 7 digits, enter it with a zero at the start."
+        not_found: Companies House couldn't find a company with this number
+        inactive: Your company must be registered as an active company
+        error: There was an error connecting with Companies House. Hopefully this is a one off and will work if you try again.

--- a/config/locales/defra_ruby/validators/email_validator/en.yml
+++ b/config/locales/defra_ruby/validators/email_validator/en.yml
@@ -2,6 +2,6 @@ en:
   defra_ruby:
     validators:
       EmailValidator:
-        email:
+        attribute:
           blank: "Enter an email address"
           invalid_format: "Enter a valid email address - there’s a mistake in that one"

--- a/config/locales/defra_ruby/validators/email_validator/en.yml
+++ b/config/locales/defra_ruby/validators/email_validator/en.yml
@@ -2,6 +2,5 @@ en:
   defra_ruby:
     validators:
       EmailValidator:
-        attribute:
-          blank: "Enter an email address"
-          invalid_format: "Enter a valid email address - there’s a mistake in that one"
+        blank: "Enter an email address"
+        invalid_format: "Enter a valid email address - there’s a mistake in that one"

--- a/config/locales/defra_ruby/validators/grid_reference_validator/en.yml
+++ b/config/locales/defra_ruby/validators/grid_reference_validator/en.yml
@@ -2,7 +2,6 @@ en:
   defra_ruby:
     validators:
       GridReferenceValidator:
-        attribute:
-          blank: Enter a grid reference
-          invalid_format: The grid reference should have 2 letters and 10 digits
-          invalid: The grid reference is not a valid coordinate
+        blank: Enter a grid reference
+        invalid_format: The grid reference should have 2 letters and 10 digits
+        invalid: The grid reference is not a valid coordinate

--- a/config/locales/defra_ruby/validators/grid_reference_validator/en.yml
+++ b/config/locales/defra_ruby/validators/grid_reference_validator/en.yml
@@ -2,7 +2,7 @@ en:
   defra_ruby:
     validators:
       GridReferenceValidator:
-        grid_reference:
+        attribute:
           blank: Enter a grid reference
           invalid_format: The grid reference should have 2 letters and 10 digits
           invalid: The grid reference is not a valid coordinate

--- a/config/locales/defra_ruby/validators/location_validator/en.yml
+++ b/config/locales/defra_ruby/validators/location_validator/en.yml
@@ -2,5 +2,4 @@ en:
   defra_ruby:
     validators:
       LocationValidator:
-        attribute:
-          inclusion: "You must answer this question"
+        inclusion: "You must answer this question"

--- a/config/locales/defra_ruby/validators/location_validator/en.yml
+++ b/config/locales/defra_ruby/validators/location_validator/en.yml
@@ -2,5 +2,5 @@ en:
   defra_ruby:
     validators:
       LocationValidator:
-        location:
+        attribute:
           inclusion: "You must answer this question"

--- a/config/locales/defra_ruby/validators/phone_number_validator/en.yml
+++ b/config/locales/defra_ruby/validators/phone_number_validator/en.yml
@@ -2,7 +2,6 @@ en:
   defra_ruby:
     validators:
       PhoneNumberValidator:
-        attribute:
-          blank: "Enter a telephone number"
-          invalid_format: "Enter a valid telephone number"
-          too_long: "Check the number you entered - it should have no more than than 15 characters"
+        blank: "Enter a telephone number"
+        invalid_format: "Enter a valid telephone number"
+        too_long: "Check the number you entered - it should have no more than than 15 characters"

--- a/config/locales/defra_ruby/validators/phone_number_validator/en.yml
+++ b/config/locales/defra_ruby/validators/phone_number_validator/en.yml
@@ -2,7 +2,7 @@ en:
   defra_ruby:
     validators:
       PhoneNumberValidator:
-        phone_number:
+        attribute:
           blank: "Enter a telephone number"
           invalid_format: "Enter a valid telephone number"
           too_long: "Check the number you entered - it should have no more than than 15 characters"

--- a/config/locales/defra_ruby/validators/position_validator/en.yml
+++ b/config/locales/defra_ruby/validators/position_validator/en.yml
@@ -2,6 +2,6 @@ en:
   defra_ruby:
     validators:
       PositionValidator:
-        position:
+        attribute:
           invalid_format: "The position must contain only letters, spaces, commas, full stops, hyphens and apostrophes"
           too_long: "The position must have no more than 70 characters"

--- a/config/locales/defra_ruby/validators/position_validator/en.yml
+++ b/config/locales/defra_ruby/validators/position_validator/en.yml
@@ -2,6 +2,5 @@ en:
   defra_ruby:
     validators:
       PositionValidator:
-        attribute:
-          invalid_format: "The position must contain only letters, spaces, commas, full stops, hyphens and apostrophes"
-          too_long: "The position must have no more than 70 characters"
+        invalid_format: "The position must contain only letters, spaces, commas, full stops, hyphens and apostrophes"
+        too_long: "The position must have no more than 70 characters"

--- a/config/locales/defra_ruby/validators/token_validator/en.yml
+++ b/config/locales/defra_ruby/validators/token_validator/en.yml
@@ -2,6 +2,6 @@ en:
   defra_ruby:
     validators:
       TokenValidator:
-        token:
+        attribute:
           invalid_format: "The token is not valid"
           blank: "The token is missing"

--- a/config/locales/defra_ruby/validators/token_validator/en.yml
+++ b/config/locales/defra_ruby/validators/token_validator/en.yml
@@ -2,6 +2,5 @@ en:
   defra_ruby:
     validators:
       TokenValidator:
-        attribute:
-          invalid_format: "The token is not valid"
-          blank: "The token is missing"
+        invalid_format: "The token is not valid"
+        blank: "The token is missing"

--- a/config/locales/defra_ruby/validators/true_false_validator/en.yml
+++ b/config/locales/defra_ruby/validators/true_false_validator/en.yml
@@ -2,5 +2,4 @@ en:
   defra_ruby:
     validators:
       TrueFalseValidator:
-        attribute:
-          inclusion: "You must answer this question"
+        inclusion: "You must answer this question"

--- a/lib/defra_ruby/validators/base_validator.rb
+++ b/lib/defra_ruby/validators/base_validator.rb
@@ -6,11 +6,11 @@ module DefraRuby
 
       protected
 
-      def error_message(attribute, error)
+      def error_message(error)
         if options[:messages] && options[:messages][error]
           options[:messages][error]
         else
-          I18n.t("defra_ruby.validators.#{class_name}.#{attribute}.#{error}")
+          I18n.t("defra_ruby.validators.#{class_name}.#{error}")
         end
       end
 

--- a/lib/defra_ruby/validators/companies_house_number_validator.rb
+++ b/lib/defra_ruby/validators/companies_house_number_validator.rb
@@ -25,14 +25,14 @@ module DefraRuby
       def value_is_present?(record, attribute, value)
         return true if value.present?
 
-        record.errors[attribute] << error_message(:company_no, :blank)
+        record.errors[attribute] << error_message(:attribute, :blank)
         false
       end
 
       def format_is_valid?(record, attribute, value)
         return true if value.match?(VALID_COMPANIES_HOUSE_REGISTRATION_NUMBER_REGEX)
 
-        record.errors[attribute] << error_message(:company_no, :invalid_format)
+        record.errors[attribute] << error_message(:attribute, :invalid_format)
         false
       end
 
@@ -41,12 +41,12 @@ module DefraRuby
         when :active
           true
         when :inactive
-          record.errors[attribute] << error_message(:company_no, :inactive)
+          record.errors[attribute] << error_message(:attribute, :inactive)
         when :not_found
-          record.errors[attribute] << error_message(:company_no, :not_found)
+          record.errors[attribute] << error_message(:attribute, :not_found)
         end
       rescue StandardError
-        record.errors[attribute] << error_message(:company_no, :error)
+        record.errors[attribute] << error_message(:attribute, :error)
       end
 
     end

--- a/lib/defra_ruby/validators/companies_house_number_validator.rb
+++ b/lib/defra_ruby/validators/companies_house_number_validator.rb
@@ -25,14 +25,14 @@ module DefraRuby
       def value_is_present?(record, attribute, value)
         return true if value.present?
 
-        record.errors[attribute] << error_message(:attribute, :blank)
+        record.errors[attribute] << error_message(:blank)
         false
       end
 
       def format_is_valid?(record, attribute, value)
         return true if value.match?(VALID_COMPANIES_HOUSE_REGISTRATION_NUMBER_REGEX)
 
-        record.errors[attribute] << error_message(:attribute, :invalid_format)
+        record.errors[attribute] << error_message(:invalid_format)
         false
       end
 
@@ -41,12 +41,12 @@ module DefraRuby
         when :active
           true
         when :inactive
-          record.errors[attribute] << error_message(:attribute, :inactive)
+          record.errors[attribute] << error_message(:inactive)
         when :not_found
-          record.errors[attribute] << error_message(:attribute, :not_found)
+          record.errors[attribute] << error_message(:not_found)
         end
       rescue StandardError
-        record.errors[attribute] << error_message(:attribute, :error)
+        record.errors[attribute] << error_message(:error)
       end
 
     end

--- a/lib/defra_ruby/validators/concerns/can_validate_characters.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_characters.rb
@@ -10,7 +10,7 @@ module DefraRuby
         # Name fields must contain only letters, spaces, commas, full stops, hyphens and apostrophes
         return true if value.match?(/\A[-a-z\s,.']+\z/i)
 
-        record.errors[attribute] << error_message(:attribute, :invalid_format)
+        record.errors[attribute] << error_message(:invalid_format)
         false
       end
 

--- a/lib/defra_ruby/validators/concerns/can_validate_characters.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_characters.rb
@@ -10,7 +10,7 @@ module DefraRuby
         # Name fields must contain only letters, spaces, commas, full stops, hyphens and apostrophes
         return true if value.match?(/\A[-a-z\s,.']+\z/i)
 
-        record.errors[attribute] << error_message(attribute, :invalid_format)
+        record.errors[attribute] << error_message(:attribute, :invalid_format)
         false
       end
 

--- a/lib/defra_ruby/validators/concerns/can_validate_length.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_length.rb
@@ -9,7 +9,7 @@ module DefraRuby
       def value_is_not_too_long?(record, attribute, value, max_length)
         return true if value.length <= max_length
 
-        record.errors[attribute] << error_message(attribute, :too_long)
+        record.errors[attribute] << error_message(:attribute, :too_long)
         false
       end
 

--- a/lib/defra_ruby/validators/concerns/can_validate_length.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_length.rb
@@ -9,7 +9,7 @@ module DefraRuby
       def value_is_not_too_long?(record, attribute, value, max_length)
         return true if value.length <= max_length
 
-        record.errors[attribute] << error_message(:attribute, :too_long)
+        record.errors[attribute] << error_message(:too_long)
         false
       end
 

--- a/lib/defra_ruby/validators/concerns/can_validate_presence.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_presence.rb
@@ -9,7 +9,7 @@ module DefraRuby
       def value_is_present?(record, attribute, value)
         return true if value.present?
 
-        record.errors[attribute] << error_message(:attribute, :blank)
+        record.errors[attribute] << error_message(:blank)
         false
       end
 

--- a/lib/defra_ruby/validators/concerns/can_validate_presence.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_presence.rb
@@ -9,7 +9,7 @@ module DefraRuby
       def value_is_present?(record, attribute, value)
         return true if value.present?
 
-        record.errors[attribute] << error_message(attribute, :blank)
+        record.errors[attribute] << error_message(:attribute, :blank)
         false
       end
 

--- a/lib/defra_ruby/validators/concerns/can_validate_selection.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_selection.rb
@@ -9,7 +9,7 @@ module DefraRuby
       def value_is_included?(record, attribute, value, valid_options)
         return true if value.present? && valid_options.include?(value)
 
-        record.errors[attribute] << error_message(attribute, :inclusion)
+        record.errors[attribute] << error_message(:attribute, :inclusion)
         false
       end
 

--- a/lib/defra_ruby/validators/concerns/can_validate_selection.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_selection.rb
@@ -9,7 +9,7 @@ module DefraRuby
       def value_is_included?(record, attribute, value, valid_options)
         return true if value.present? && valid_options.include?(value)
 
-        record.errors[attribute] << error_message(:attribute, :inclusion)
+        record.errors[attribute] << error_message(:inclusion)
         false
       end
 

--- a/lib/defra_ruby/validators/email_validator.rb
+++ b/lib/defra_ruby/validators/email_validator.rb
@@ -19,7 +19,7 @@ module DefraRuby
         # validate_email_format returns nil if the validation passes
         return true unless ValidatesEmailFormatOf.validate_email_format(value)
 
-        record.errors[attribute] << error_message(:attribute, :invalid_format)
+        record.errors[attribute] << error_message(:invalid_format)
         false
       end
 

--- a/lib/defra_ruby/validators/email_validator.rb
+++ b/lib/defra_ruby/validators/email_validator.rb
@@ -19,7 +19,7 @@ module DefraRuby
         # validate_email_format returns nil if the validation passes
         return true unless ValidatesEmailFormatOf.validate_email_format(value)
 
-        record.errors[attribute] << error_message(:email, :invalid_format)
+        record.errors[attribute] << error_message(:attribute, :invalid_format)
         false
       end
 

--- a/lib/defra_ruby/validators/grid_reference_validator.rb
+++ b/lib/defra_ruby/validators/grid_reference_validator.rb
@@ -22,7 +22,7 @@ module DefraRuby
       def valid_format?(record, attribute, value)
         return true if value.match?(/\A#{grid_reference_pattern}\z/)
 
-        record.errors[attribute] << error_message(:grid_reference, :invalid_format)
+        record.errors[attribute] << error_message(:attribute, :invalid_format)
         false
       end
 
@@ -30,7 +30,7 @@ module DefraRuby
         OsMapRef::Location.for(value).easting
         true
       rescue OsMapRef::Error
-        record.errors[attribute] << error_message(:grid_reference, :invalid)
+        record.errors[attribute] << error_message(:attribute, :invalid)
         false
       end
 

--- a/lib/defra_ruby/validators/grid_reference_validator.rb
+++ b/lib/defra_ruby/validators/grid_reference_validator.rb
@@ -22,7 +22,7 @@ module DefraRuby
       def valid_format?(record, attribute, value)
         return true if value.match?(/\A#{grid_reference_pattern}\z/)
 
-        record.errors[attribute] << error_message(:attribute, :invalid_format)
+        record.errors[attribute] << error_message(:invalid_format)
         false
       end
 
@@ -30,7 +30,7 @@ module DefraRuby
         OsMapRef::Location.for(value).easting
         true
       rescue OsMapRef::Error
-        record.errors[attribute] << error_message(:attribute, :invalid)
+        record.errors[attribute] << error_message(:invalid)
         false
       end
 

--- a/lib/defra_ruby/validators/phone_number_validator.rb
+++ b/lib/defra_ruby/validators/phone_number_validator.rb
@@ -23,7 +23,7 @@ module DefraRuby
         Phonelib.default_country = "GB"
         return true if Phonelib.valid?(value)
 
-        record.errors[attribute] << error_message(:attribute, :invalid_format)
+        record.errors[attribute] << error_message(:invalid_format)
         false
       end
 

--- a/lib/defra_ruby/validators/phone_number_validator.rb
+++ b/lib/defra_ruby/validators/phone_number_validator.rb
@@ -23,7 +23,7 @@ module DefraRuby
         Phonelib.default_country = "GB"
         return true if Phonelib.valid?(value)
 
-        record.errors[attribute] << error_message(:phone_number, :invalid_format)
+        record.errors[attribute] << error_message(:attribute, :invalid_format)
         false
       end
 

--- a/lib/defra_ruby/validators/token_validator.rb
+++ b/lib/defra_ruby/validators/token_validator.rb
@@ -19,7 +19,7 @@ module DefraRuby
         # 24-character unique tokens
         return true if value.length == 24
 
-        record.errors[attribute] << error_message(:token, :invalid_format)
+        record.errors[attribute] << error_message(:attribute, :invalid_format)
         false
       end
     end

--- a/lib/defra_ruby/validators/token_validator.rb
+++ b/lib/defra_ruby/validators/token_validator.rb
@@ -19,7 +19,7 @@ module DefraRuby
         # 24-character unique tokens
         return true if value.length == 24
 
-        record.errors[attribute] << error_message(:attribute, :invalid_format)
+        record.errors[attribute] << error_message(:invalid_format)
         false
       end
     end

--- a/spec/defra_ruby/validators/business_type_validator_spec.rb
+++ b/spec/defra_ruby/validators/business_type_validator_spec.rb
@@ -42,7 +42,7 @@ module DefraRuby
             allow_any_instance_of(DefraRuby::Validators::BaseValidator).to receive(:options).and_return({})
           end
 
-          error_message = Helpers::Translator.error_message(BusinessTypeValidator, :business_type, :inclusion)
+          error_message = Helpers::Translator.error_message(BusinessTypeValidator, :inclusion)
 
           it_behaves_like "an invalid record",
                           validatable: validatable,

--- a/spec/defra_ruby/validators/companies_house_number_validator_spec.rb
+++ b/spec/defra_ruby/validators/companies_house_number_validator_spec.rb
@@ -37,11 +37,7 @@ module DefraRuby
         context "when given an invalid company number" do
           context "because it is blank" do
             validatable = Test::CompaniesHouseNumberValidatable.new
-            error_message = Helpers::Translator.error_message(
-              CompaniesHouseNumberValidator,
-              :company_no,
-              :blank
-            )
+            error_message = Helpers::Translator.error_message(CompaniesHouseNumberValidator, :blank)
 
             it_behaves_like "an invalid record",
                             validatable: validatable,
@@ -52,11 +48,7 @@ module DefraRuby
 
           context "because the format is wrong" do
             validatable = Test::CompaniesHouseNumberValidatable.new(invalid_format_number)
-            error_message = Helpers::Translator.error_message(
-              CompaniesHouseNumberValidator,
-              :company_no,
-              :invalid_format
-            )
+            error_message = Helpers::Translator.error_message(CompaniesHouseNumberValidator, :invalid_format)
 
             it_behaves_like "an invalid record",
                             validatable: validatable,
@@ -71,11 +63,7 @@ module DefraRuby
             end
 
             validatable = Test::CompaniesHouseNumberValidatable.new(unknown_number)
-            error_message = Helpers::Translator.error_message(
-              CompaniesHouseNumberValidator,
-              :company_no,
-              :not_found
-            )
+            error_message = Helpers::Translator.error_message(CompaniesHouseNumberValidator, :not_found)
 
             it_behaves_like "an invalid record",
                             validatable: validatable,
@@ -90,11 +78,7 @@ module DefraRuby
             end
 
             validatable = Test::CompaniesHouseNumberValidatable.new(inactive_number)
-            error_message = Helpers::Translator.error_message(
-              CompaniesHouseNumberValidator,
-              :company_no,
-              :inactive
-            )
+            error_message = Helpers::Translator.error_message(CompaniesHouseNumberValidator, :inactive)
 
             it_behaves_like "an invalid record",
                             validatable: validatable,
@@ -110,11 +94,7 @@ module DefraRuby
           end
 
           validatable = Test::CompaniesHouseNumberValidatable.new(valid_numbers.sample)
-          error_message = Helpers::Translator.error_message(
-            CompaniesHouseNumberValidator,
-            :company_no,
-            :error
-          )
+          error_message = Helpers::Translator.error_message(CompaniesHouseNumberValidator, :error)
 
           it_behaves_like "an invalid record",
                           validatable: validatable,

--- a/spec/defra_ruby/validators/email_validator_spec.rb
+++ b/spec/defra_ruby/validators/email_validator_spec.rb
@@ -31,7 +31,7 @@ module DefraRuby
           context "because the email is not correctly formatted" do
             validatable = Test::EmailValidatable.new(invalid_email)
 
-            error_message = Helpers::Translator.error_message(EmailValidator, :email, :invalid_format)
+            error_message = Helpers::Translator.error_message(EmailValidator, :invalid_format)
 
             it_behaves_like "an invalid record",
                             validatable: validatable,

--- a/spec/defra_ruby/validators/grid_reference_validator_spec.rb
+++ b/spec/defra_ruby/validators/grid_reference_validator_spec.rb
@@ -31,7 +31,7 @@ module DefraRuby
         context "when the grid reference is not valid" do
           context "because the grid reference is not correctly formatted" do
             validatable = Test::GridReferenceValidatable.new(invalid_grid_reference)
-            error_message = Helpers::Translator.error_message(GridReferenceValidator, :grid_reference, :invalid_format)
+            error_message = Helpers::Translator.error_message(GridReferenceValidator, :invalid_format)
 
             it_behaves_like "an invalid record",
                             validatable: validatable,
@@ -42,7 +42,7 @@ module DefraRuby
 
           context "because the grid reference is not a coordinate" do
             validatable = Test::GridReferenceValidatable.new(non_coordinate_grid_reference)
-            error_message = Helpers::Translator.error_message(GridReferenceValidator, :grid_reference, :invalid)
+            error_message = Helpers::Translator.error_message(GridReferenceValidator, :invalid)
 
             it_behaves_like "an invalid record",
                             validatable: validatable,

--- a/spec/defra_ruby/validators/location_validator_spec.rb
+++ b/spec/defra_ruby/validators/location_validator_spec.rb
@@ -42,7 +42,7 @@ module DefraRuby
             allow_any_instance_of(DefraRuby::Validators::BaseValidator).to receive(:options).and_return({})
           end
 
-          error_message = Helpers::Translator.error_message(LocationValidator, :location, :inclusion)
+          error_message = Helpers::Translator.error_message(LocationValidator, :inclusion)
 
           it_behaves_like "an invalid record",
                           validatable: validatable,

--- a/spec/defra_ruby/validators/phone_number_validator_spec.rb
+++ b/spec/defra_ruby/validators/phone_number_validator_spec.rb
@@ -44,7 +44,7 @@ module DefraRuby
         context "when the phone number is not valid" do
           context "because the phone number is not correctly formatted" do
             validatable = Test::PhoneNumberValidatable.new(invalid_number)
-            error_message = Helpers::Translator.error_message(PhoneNumberValidator, :phone_number, :invalid_format)
+            error_message = Helpers::Translator.error_message(PhoneNumberValidator, :invalid_format)
 
             it_behaves_like "an invalid record",
                             validatable: validatable,

--- a/spec/defra_ruby/validators/token_validator_spec.rb
+++ b/spec/defra_ruby/validators/token_validator_spec.rb
@@ -30,7 +30,7 @@ module DefraRuby
         context "when the token is not valid" do
           context "because the token is not correctly formatted" do
             validatable = Test::TokenValidatable.new(invalid_token)
-            error_message = Helpers::Translator.error_message(TokenValidator, :token, :invalid_format)
+            error_message = Helpers::Translator.error_message(TokenValidator, :invalid_format)
 
             it_behaves_like "an invalid record",
                             validatable: validatable,

--- a/spec/support/helpers/translator.rb
+++ b/spec/support/helpers/translator.rb
@@ -2,10 +2,10 @@
 
 module Helpers
   module Translator
-    def self.error_message(klass, attribute, error)
+    def self.error_message(klass, error)
       class_name = klass_name(klass)
 
-      I18n.t("defra_ruby.validators.#{class_name}.#{attribute}.#{error}")
+      I18n.t("defra_ruby.validators.#{class_name}.attribute.#{error}")
     end
 
     def self.klass_name(klass)

--- a/spec/support/helpers/translator.rb
+++ b/spec/support/helpers/translator.rb
@@ -5,7 +5,7 @@ module Helpers
     def self.error_message(klass, error)
       class_name = klass_name(klass)
 
-      I18n.t("defra_ruby.validators.#{class_name}.attribute.#{error}")
+      I18n.t("defra_ruby.validators.#{class_name}.#{error}")
     end
 
     def self.klass_name(klass)

--- a/spec/support/shared_examples/validators/characters_validator.rb
+++ b/spec/support/shared_examples/validators/characters_validator.rb
@@ -16,7 +16,7 @@ RSpec.shared_examples "a characters validator" do |validator, validatable_class,
     context "when the #{attribute} is not valid" do
       context "because the #{attribute} is not correctly formatted" do
         validatable = validatable_class.new(values[:invalid])
-        error_message = Helpers::Translator.error_message(validator, attribute, :invalid_format)
+        error_message = Helpers::Translator.error_message(validator, :invalid_format)
 
         it_behaves_like "an invalid record",
                         validatable: validatable,

--- a/spec/support/shared_examples/validators/length_validator.rb
+++ b/spec/support/shared_examples/validators/length_validator.rb
@@ -16,7 +16,7 @@ RSpec.shared_examples "a length validator" do |validator, validatable_class, att
     context "when the #{attribute} is not valid" do
       context "because the #{attribute} is too long" do
         validatable = validatable_class.new(values[:invalid])
-        error_message = Helpers::Translator.error_message(validator, attribute, :too_long)
+        error_message = Helpers::Translator.error_message(validator, :too_long)
 
         it_behaves_like "an invalid record",
                         validatable: validatable,

--- a/spec/support/shared_examples/validators/presence_validator.rb
+++ b/spec/support/shared_examples/validators/presence_validator.rb
@@ -16,7 +16,7 @@ RSpec.shared_examples "a presence validator" do |validator, validatable_class, a
     context "when the #{attribute} is not valid" do
       context "because the #{attribute} is not present" do
         validatable = validatable_class.new
-        error_message = Helpers::Translator.error_message(validator, attribute, :blank)
+        error_message = Helpers::Translator.error_message(validator, :blank)
 
         it_behaves_like "an invalid record",
                         validatable: validatable,

--- a/spec/support/shared_examples/validators/selection_validator.rb
+++ b/spec/support/shared_examples/validators/selection_validator.rb
@@ -16,7 +16,7 @@ RSpec.shared_examples "a selection validator" do |validator, validatable_class, 
     context "when the #{attribute} is not valid" do
       context "because the #{attribute} is not present" do
         validatable = validatable_class.new
-        error_message = Helpers::Translator.error_message(validator, attribute, :inclusion)
+        error_message = Helpers::Translator.error_message(validator, :inclusion)
 
         it_behaves_like "an invalid record",
                         validatable: validatable,
@@ -27,7 +27,7 @@ RSpec.shared_examples "a selection validator" do |validator, validatable_class, 
 
       context "because the #{attribute} is not from an approved list" do
         validatable = validatable_class.new(values[:invalid])
-        error_message = Helpers::Translator.error_message(validator, attribute, :inclusion)
+        error_message = Helpers::Translator.error_message(validator, :inclusion)
 
         it_behaves_like "an invalid record",
                         validatable: validatable,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-561

We recently modified the validator to not expect specific attribute names and just accept the attribute name that was passed in.

However, our default error messages still relied on a specific attribute name. This was fine for validators which are only used on a single attribute with a specific attribute name, but for validators that were used on lots of attributes (specifically the TrueFalseValidator) it resulted in a translation error.

This commit changes our error message adding to just use a generic `:attribute` value, so we should get the correct default error no matter what.