### PR TITLE
Change true false validator to match true and false objects

### DIFF
--- a/lib/defra_ruby/validators/concerns/can_validate_selection.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_selection.rb
@@ -7,7 +7,8 @@ module DefraRuby
       private
 
       def value_is_included?(record, attribute, value, valid_options)
-        return true if value.present? && valid_options.include?(value)
+        # In this case, we do want `false.present?` to return `true` https://github.com/rails/rails/issues/10804
+        return true if (value == false || value.present?) && valid_options.include?(value)
 
         record.errors[attribute] << error_message(:inclusion)
         false

--- a/lib/defra_ruby/validators/true_false_validator.rb
+++ b/lib/defra_ruby/validators/true_false_validator.rb
@@ -6,7 +6,7 @@ module DefraRuby
       include CanValidateSelection
 
       def validate_each(record, attribute, value)
-        valid_options = %w[true false]
+        valid_options = [true, false]
 
         value_is_included?(record, attribute, value, valid_options)
       end

--- a/spec/cassettes/company_no_inactive.yml
+++ b/spec/cassettes/company_no_inactive.yml
@@ -9,10 +9,10 @@ http_interactions:
     headers:
       Accept:
       - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.2p198
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.2p198
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
       - api.companieshouse.gov.uk
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 20 Aug 2019 14:28:41 GMT
+      - Mon, 30 Sep 2019 13:21:55 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -49,9 +49,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '600'
       X-Ratelimit-Remain:
-      - '590'
+      - '597'
       X-Ratelimit-Reset:
-      - '1566311455'
+      - '1569850005'
       X-Ratelimit-Window:
       - 5m
       Server:
@@ -63,5 +63,5 @@ http_interactions:
         Elizabeth House","address_line_2":"54-58 High Street"},"undeliverable_registered_office_address":false,"company_name":"DIRECT
         SKIPS UK LTD","annual_return":{"last_made_up_to":"2014-06-11"},"jurisdiction":"england-wales","etag":"1cdef5bc2a020b3e9003b086033b64b78bcb28f6","company_status":"dissolved","has_insolvency_history":false,"has_charges":false,"links":{"self":"/company/07281919","filing_history":"/company/07281919/filing-history","officers":"/company/07281919/officers"},"date_of_cessation":"2016-01-05","can_file":false}'
     http_version: 
-  recorded_at: Tue, 20 Aug 2019 14:28:41 GMT
+  recorded_at: Mon, 30 Sep 2019 13:21:54 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/company_no_not_found.yml
+++ b/spec/cassettes/company_no_not_found.yml
@@ -9,10 +9,10 @@ http_interactions:
     headers:
       Accept:
       - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.2p198
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.2p198
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
       - api.companieshouse.gov.uk
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Tue, 20 Aug 2019 14:28:41 GMT
+      - Mon, 30 Sep 2019 13:21:55 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -49,16 +49,16 @@ http_interactions:
       X-Ratelimit-Limit:
       - '600'
       X-Ratelimit-Remain:
-      - '591'
+      - '598'
       X-Ratelimit-Reset:
-      - '1566311455'
+      - '1569850005'
       X-Ratelimit-Window:
       - 5m
       Server:
       - CompaniesHouse
     body:
       encoding: UTF-8
-      string: '{"errors":[{"type":"ch:service","error":"company-profile-not-found"}]}'
+      string: '{"errors":[{"error":"company-profile-not-found","type":"ch:service"}]}'
     http_version: 
-  recorded_at: Tue, 20 Aug 2019 14:28:41 GMT
+  recorded_at: Mon, 30 Sep 2019 13:21:54 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/company_no_valid.yml
+++ b/spec/cassettes/company_no_valid.yml
@@ -9,10 +9,10 @@ http_interactions:
     headers:
       Accept:
       - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
-      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.4.2p198
+      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.2p198
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
       - api.companieshouse.gov.uk
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 20 Aug 2019 14:28:40 GMT
+      - Mon, 30 Sep 2019 13:21:56 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -49,17 +49,17 @@ http_interactions:
       X-Ratelimit-Limit:
       - '600'
       X-Ratelimit-Remain:
-      - '592'
+      - '596'
       X-Ratelimit-Reset:
-      - '1566311455'
+      - '1569850005'
       X-Ratelimit-Window:
       - 5m
       Server:
       - CompaniesHouse
     body:
       encoding: UTF-8
-      string: '{"type":"ltd","company_name":"0800 WASTE LTD.","has_insolvency_history":false,"accounts":{"next_due":"2019-09-30","next_made_up_to":"2018-12-31","next_accounts":{"overdue":false,"period_start_on":"2018-01-01","due_on":"2019-09-30","period_end_on":"2018-12-31"},"accounting_reference_date":{"month":"12","day":"31"},"last_accounts":{"period_end_on":"2017-12-31","period_start_on":"2017-01-01","made_up_to":"2017-12-31"},"overdue":false},"undeliverable_registered_office_address":false,"etag":"0ec9d00cab0ffee2ef1f5d59f4f714fa5b1618f5","company_number":"09360070","registered_office_address":{"postal_code":"SM3
-        9ND","locality":"Sutton","region":"Surrey","address_line_1":"21 Haslam Avenue"},"jurisdiction":"england-wales","date_of_creation":"2014-12-18","company_status":"active","has_charges":false,"sic_codes":["38110"],"last_full_members_list_date":"2015-12-18","confirmation_statement":{"overdue":false,"next_made_up_to":"2020-01-23","last_made_up_to":"2019-01-23","next_due":"2020-02-06"},"links":{"self":"/company/09360070","filing_history":"/company/09360070/filing-history","officers":"/company/09360070/officers"},"registered_office_is_in_dispute":false,"can_file":true}'
+      string: '{"type":"ltd","company_name":"0800 WASTE LTD.","has_insolvency_history":false,"accounts":{"accounting_reference_date":{"month":"12","day":"31"},"last_accounts":{"made_up_to":"2018-12-31","period_start_on":"2018-01-01","period_end_on":"2018-12-31"},"next_due":"2020-09-30","next_accounts":{"period_start_on":"2019-01-01","period_end_on":"2019-12-31","due_on":"2020-09-30","overdue":false},"next_made_up_to":"2019-12-31","overdue":false},"undeliverable_registered_office_address":false,"etag":"b2cacfcd5399fb7065ce1c074df1567771c68f9d","company_number":"09360070","registered_office_address":{"locality":"Sutton","postal_code":"SM3
+        9ND","region":"Surrey","address_line_1":"21 Haslam Avenue"},"jurisdiction":"england-wales","date_of_creation":"2014-12-18","company_status":"active","has_charges":false,"sic_codes":["38110"],"last_full_members_list_date":"2015-12-18","confirmation_statement":{"next_due":"2020-02-06","overdue":false,"next_made_up_to":"2020-01-23","last_made_up_to":"2019-01-23"},"links":{"self":"/company/09360070","filing_history":"/company/09360070/filing-history","officers":"/company/09360070/officers"},"registered_office_is_in_dispute":false,"can_file":true}'
     http_version: 
-  recorded_at: Tue, 20 Aug 2019 14:28:40 GMT
+  recorded_at: Mon, 30 Sep 2019 13:21:54 GMT
 recorded_with: VCR 4.0.0

--- a/spec/defra_ruby/validators/true_false_validator_spec.rb
+++ b/spec/defra_ruby/validators/true_false_validator_spec.rb
@@ -13,17 +13,24 @@ end
 module DefraRuby
   module Validators
     RSpec.describe TrueFalseValidator do
-
-      valid_value = [true, false].sample
       invalid_value = "unsure"
 
       it_behaves_like("a validator")
+
       it_behaves_like(
         "a selection validator",
         TrueFalseValidator,
         Test::TrueFalseValidatable,
         :attribute,
-        valid: valid_value, invalid: invalid_value
+        valid: true, invalid: invalid_value
+      )
+
+      it_behaves_like(
+        "a selection validator",
+        TrueFalseValidator,
+        Test::TrueFalseValidatable,
+        :attribute,
+        valid: false, invalid: invalid_value
       )
     end
   end

--- a/spec/defra_ruby/validators/true_false_validator_spec.rb
+++ b/spec/defra_ruby/validators/true_false_validator_spec.rb
@@ -14,7 +14,7 @@ module DefraRuby
   module Validators
     RSpec.describe TrueFalseValidator do
 
-      valid_value = %w[true false].sample
+      valid_value = [true, false].sample
       invalid_value = "unsure"
 
       it_behaves_like("a validator")


### PR DESCRIPTION
In the current forms we are matching agains strings because we use to pass to the validator what is coming from the view.
Rails, however, would convert the string to a proper boolean value when the value is assigned to the object, and in the current form refactoring we would first assign the value to rails and then validate it. Hence we will be back dealing with proper booleans, and we don't need this validator to deal with strings but with booleans.