### PR TITLE
Update VCR cassettes

### DIFF
--- a/spec/cassettes/company_no_inactive.yml
+++ b/spec/cassettes/company_no_inactive.yml
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.2p198
+      - rest-client/2.1.0 (darwin19.0.0 x86_64) ruby/2.4.2p198
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Sep 2019 13:21:55 GMT
+      - Tue, 19 Nov 2019 22:35:56 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -51,7 +51,7 @@ http_interactions:
       X-Ratelimit-Remain:
       - '597'
       X-Ratelimit-Reset:
-      - '1569850005'
+      - '1574203256'
       X-Ratelimit-Window:
       - 5m
       Server:
@@ -63,5 +63,5 @@ http_interactions:
         Elizabeth House","address_line_2":"54-58 High Street"},"undeliverable_registered_office_address":false,"company_name":"DIRECT
         SKIPS UK LTD","annual_return":{"last_made_up_to":"2014-06-11"},"jurisdiction":"england-wales","etag":"1cdef5bc2a020b3e9003b086033b64b78bcb28f6","company_status":"dissolved","has_insolvency_history":false,"has_charges":false,"links":{"self":"/company/07281919","filing_history":"/company/07281919/filing-history","officers":"/company/07281919/officers"},"date_of_cessation":"2016-01-05","can_file":false}'
     http_version: 
-  recorded_at: Mon, 30 Sep 2019 13:21:54 GMT
+  recorded_at: Tue, 19 Nov 2019 22:35:50 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/company_no_not_found.yml
+++ b/spec/cassettes/company_no_not_found.yml
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.2p198
+      - rest-client/2.1.0 (darwin19.0.0 x86_64) ruby/2.4.2p198
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -23,7 +23,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Mon, 30 Sep 2019 13:21:55 GMT
+      - Tue, 19 Nov 2019 22:35:56 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -49,16 +49,16 @@ http_interactions:
       X-Ratelimit-Limit:
       - '600'
       X-Ratelimit-Remain:
-      - '598'
+      - '599'
       X-Ratelimit-Reset:
-      - '1569850005'
+      - '1574203256'
       X-Ratelimit-Window:
       - 5m
       Server:
       - CompaniesHouse
     body:
       encoding: UTF-8
-      string: '{"errors":[{"error":"company-profile-not-found","type":"ch:service"}]}'
+      string: '{"errors":[{"type":"ch:service","error":"company-profile-not-found"}]}'
     http_version: 
-  recorded_at: Mon, 30 Sep 2019 13:21:54 GMT
+  recorded_at: Tue, 19 Nov 2019 22:35:50 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/company_no_valid.yml
+++ b/spec/cassettes/company_no_valid.yml
@@ -10,7 +10,7 @@ http_interactions:
       Accept:
       - "*/*"
       User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/2.4.2p198
+      - rest-client/2.1.0 (darwin19.0.0 x86_64) ruby/2.4.2p198
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Host:
@@ -23,11 +23,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Sep 2019 13:21:56 GMT
+      - Tue, 19 Nov 2019 22:35:56 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '1178'
+      - '1266'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -49,9 +49,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '600'
       X-Ratelimit-Remain:
-      - '596'
+      - '598'
       X-Ratelimit-Reset:
-      - '1569850005'
+      - '1574203256'
       X-Ratelimit-Window:
       - 5m
       Server:
@@ -59,7 +59,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"type":"ltd","company_name":"0800 WASTE LTD.","has_insolvency_history":false,"accounts":{"accounting_reference_date":{"month":"12","day":"31"},"last_accounts":{"made_up_to":"2018-12-31","period_start_on":"2018-01-01","period_end_on":"2018-12-31"},"next_due":"2020-09-30","next_accounts":{"period_start_on":"2019-01-01","period_end_on":"2019-12-31","due_on":"2020-09-30","overdue":false},"next_made_up_to":"2019-12-31","overdue":false},"undeliverable_registered_office_address":false,"etag":"b2cacfcd5399fb7065ce1c074df1567771c68f9d","company_number":"09360070","registered_office_address":{"locality":"Sutton","postal_code":"SM3
-        9ND","region":"Surrey","address_line_1":"21 Haslam Avenue"},"jurisdiction":"england-wales","date_of_creation":"2014-12-18","company_status":"active","has_charges":false,"sic_codes":["38110"],"last_full_members_list_date":"2015-12-18","confirmation_statement":{"next_due":"2020-02-06","overdue":false,"next_made_up_to":"2020-01-23","last_made_up_to":"2019-01-23"},"links":{"self":"/company/09360070","filing_history":"/company/09360070/filing-history","officers":"/company/09360070/officers"},"registered_office_is_in_dispute":false,"can_file":true}'
+        9ND","region":"Surrey","address_line_1":"21 Haslam Avenue"},"jurisdiction":"england-wales","date_of_creation":"2014-12-18","company_status":"active","has_charges":false,"sic_codes":["38110"],"last_full_members_list_date":"2015-12-18","confirmation_statement":{"next_due":"2020-02-06","overdue":false,"next_made_up_to":"2020-01-23","last_made_up_to":"2019-01-23"},"links":{"self":"/company/09360070","filing_history":"/company/09360070/filing-history","officers":"/company/09360070/officers","persons_with_significant_control":"/company/09360070/persons-with-significant-control"},"registered_office_is_in_dispute":false,"can_file":true}'
     http_version: 
-  recorded_at: Mon, 30 Sep 2019 13:21:54 GMT
+  recorded_at: Tue, 19 Nov 2019 22:35:50 GMT
 recorded_with: VCR 4.0.0


### PR DESCRIPTION
Our VCR cassettes are set to expire every 14 days, at which point when running the tests they will try to connect to the live service rather than use the cassette.

This means periodically we need to ensure the cassettes are else our CI builds will begin to fail.