### PR TITLE
Fix bin/console

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "defra/ruby/validators"
+require "defra_ruby/validators"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/bin/console
+++ b/bin/console
@@ -6,9 +6,5 @@ require "defra_ruby/validators"
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
-require "irb"
-IRB.start(__FILE__)
+require "pry"
+Pry.start


### PR DESCRIPTION
Sometimes its useful to be able to load the gem and interact with the classes inorder to test and debug the code.

A great way to do this is the `bin/console` file found in most gems. However the version in this gem raises an error when you try and us it.

This change covers resolving the error.