### PR TITLE
Update VCR cassettes

### DIFF
--- a/spec/cassettes/company_no_inactive.yml
+++ b/spec/cassettes/company_no_inactive.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Jan 2020 14:02:57 GMT
+      - Wed, 29 Jan 2020 13:39:21 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -49,9 +49,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '600'
       X-Ratelimit-Remain:
-      - '597'
+      - '598'
       X-Ratelimit-Reset:
-      - '1578060475'
+      - '1580305461'
       X-Ratelimit-Window:
       - 5m
       Server:
@@ -63,5 +63,5 @@ http_interactions:
         Elizabeth House","address_line_2":"54-58 High Street"},"undeliverable_registered_office_address":false,"company_name":"DIRECT
         SKIPS UK LTD","annual_return":{"last_made_up_to":"2014-06-11"},"jurisdiction":"england-wales","etag":"1cdef5bc2a020b3e9003b086033b64b78bcb28f6","company_status":"dissolved","has_insolvency_history":false,"has_charges":false,"links":{"self":"/company/07281919","filing_history":"/company/07281919/filing-history","officers":"/company/07281919/officers"},"date_of_cessation":"2016-01-05","can_file":false}'
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 14:02:57 GMT
+  recorded_at: Wed, 29 Jan 2020 13:39:21 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/company_no_not_found.yml
+++ b/spec/cassettes/company_no_not_found.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 03 Jan 2020 14:02:55 GMT
+      - Wed, 29 Jan 2020 13:39:21 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -49,16 +49,16 @@ http_interactions:
       X-Ratelimit-Limit:
       - '600'
       X-Ratelimit-Remain:
-      - '599'
+      - '597'
       X-Ratelimit-Reset:
-      - '1578060475'
+      - '1580305461'
       X-Ratelimit-Window:
       - 5m
       Server:
       - CompaniesHouse
     body:
       encoding: UTF-8
-      string: '{"errors":[{"error":"company-profile-not-found","type":"ch:service"}]}'
+      string: '{"errors":[{"type":"ch:service","error":"company-profile-not-found"}]}'
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 14:02:55 GMT
+  recorded_at: Wed, 29 Jan 2020 13:39:21 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/company_no_valid.yml
+++ b/spec/cassettes/company_no_valid.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 03 Jan 2020 14:02:57 GMT
+      - Wed, 29 Jan 2020 13:39:21 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -49,17 +49,17 @@ http_interactions:
       X-Ratelimit-Limit:
       - '600'
       X-Ratelimit-Remain:
-      - '596'
+      - '599'
       X-Ratelimit-Reset:
-      - '1578060475'
+      - '1580305461'
       X-Ratelimit-Window:
       - 5m
       Server:
       - CompaniesHouse
     body:
       encoding: UTF-8
-      string: '{"type":"ltd","company_name":"0800 WASTE LTD.","has_insolvency_history":false,"accounts":{"accounting_reference_date":{"month":"12","day":"31"},"last_accounts":{"made_up_to":"2018-12-31","period_start_on":"2018-01-01","period_end_on":"2018-12-31"},"next_due":"2020-09-30","next_accounts":{"period_start_on":"2019-01-01","period_end_on":"2019-12-31","due_on":"2020-09-30","overdue":false},"next_made_up_to":"2019-12-31","overdue":false},"undeliverable_registered_office_address":false,"etag":"b2cacfcd5399fb7065ce1c074df1567771c68f9d","company_number":"09360070","registered_office_address":{"locality":"Sutton","postal_code":"SM3
-        9ND","region":"Surrey","address_line_1":"21 Haslam Avenue"},"jurisdiction":"england-wales","date_of_creation":"2014-12-18","company_status":"active","has_charges":false,"sic_codes":["38110"],"last_full_members_list_date":"2015-12-18","confirmation_statement":{"next_due":"2020-02-06","overdue":false,"next_made_up_to":"2020-01-23","last_made_up_to":"2019-01-23"},"links":{"self":"/company/09360070","filing_history":"/company/09360070/filing-history","officers":"/company/09360070/officers","persons_with_significant_control":"/company/09360070/persons-with-significant-control"},"registered_office_is_in_dispute":false,"can_file":true}'
+      string: '{"type":"ltd","company_name":"0800 WASTE LTD.","has_insolvency_history":false,"accounts":{"next_made_up_to":"2019-12-31","next_due":"2020-09-30","last_accounts":{"made_up_to":"2018-12-31","period_start_on":"2018-01-01","period_end_on":"2018-12-31"},"next_accounts":{"due_on":"2020-09-30","period_start_on":"2019-01-01","period_end_on":"2019-12-31","overdue":false},"overdue":false,"accounting_reference_date":{"month":"12","day":"31"}},"undeliverable_registered_office_address":false,"etag":"73621f5f3d59c8eb519bcbaac46f850c92018216","company_number":"09360070","registered_office_address":{"postal_code":"SM3
+        9ND","locality":"Sutton","address_line_1":"21 Haslam Avenue","region":"Surrey"},"jurisdiction":"england-wales","date_of_creation":"2014-12-18","company_status":"active","has_charges":false,"sic_codes":["38110"],"last_full_members_list_date":"2015-12-18","confirmation_statement":{"next_due":"2021-02-03","next_made_up_to":"2021-01-20","overdue":false,"last_made_up_to":"2020-01-20"},"links":{"self":"/company/09360070","filing_history":"/company/09360070/filing-history","officers":"/company/09360070/officers","persons_with_significant_control":"/company/09360070/persons-with-significant-control"},"registered_office_is_in_dispute":false,"can_file":true}'
     http_version: 
-  recorded_at: Fri, 03 Jan 2020 14:02:57 GMT
+  recorded_at: Wed, 29 Jan 2020 13:39:21 GMT
 recorded_with: VCR 4.0.0


### PR DESCRIPTION
Every 14 days the VCR cassettes expire and we need to update them to ensure we are still working as expected with the current API of the external services we use.