### PR TITLE
Restrict dates to be greater or equal to year 1900

### DIFF
--- a/config/locales/defra_ruby/validators/past_date_validator/en.yml
+++ b/config/locales/defra_ruby/validators/past_date_validator/en.yml
@@ -3,3 +3,4 @@ en:
     validators:
       PastDateValidator:
         past_date: "Date cannot be in the future"
+        invalid_date: "You must enter a valid date"

--- a/lib/defra_ruby/validators/past_date_validator.rb
+++ b/lib/defra_ruby/validators/past_date_validator.rb
@@ -6,11 +6,21 @@ module DefraRuby
       def validate_each(record, attribute, value)
         return false if value.blank?
 
-        return true if value.to_date <= Date.today
+        date = value.to_date
 
-        record.errors[attribute] << error_message(:past_date)
+        if date > Date.today
+          record.errors[attribute] << error_message(:past_date)
 
-        false
+          return false
+        end
+
+        if date.year < 1900
+          record.errors[attribute] << error_message(:invalid_date)
+
+          return false
+        end
+
+        true
       end
     end
   end

--- a/spec/defra_ruby/validators/past_date_validator_spec.rb
+++ b/spec/defra_ruby/validators/past_date_validator_spec.rb
@@ -15,14 +15,21 @@ module DefraRuby
     RSpec.describe PastDateValidator, type: :model do
 
       valid_date = Date.today
-      invalid_date = Date.today + 1
+      future_date = Date.today + 1
+      invalid_date = Date.new(20, 2, 2)
 
       it_behaves_like "a valid record", Test::PastDateValidatable.new(valid_date)
       it_behaves_like "an invalid record",
-                      validatable: Test::PastDateValidatable.new(invalid_date),
+                      validatable: Test::PastDateValidatable.new(future_date),
                       attribute: :date,
                       error: :past_date,
                       error_message: Helpers::Translator.error_message(PastDateValidator, :past_date)
+
+      it_behaves_like "an invalid record",
+                      validatable: Test::PastDateValidatable.new(invalid_date),
+                      attribute: :date,
+                      error: :invalid_date,
+                      error_message: Helpers::Translator.error_message(PastDateValidator, :invalid_date)
     end
   end
 end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-903

This restrict dates to be greater or equal to the year 1900.