### PR TITLE
Update syntax for adding error messages in Rails 6

### DIFF
--- a/lib/defra_ruby/validators/base_validator.rb
+++ b/lib/defra_ruby/validators/base_validator.rb
@@ -6,6 +6,12 @@ module DefraRuby
 
       protected
 
+      def add_validation_error(record, attribute, error)
+        record.errors.add(attribute,
+                          error,
+                          message: error_message(error))
+      end
+
       def error_message(error)
         if options[:messages] && options[:messages][error]
           options[:messages][error]

--- a/lib/defra_ruby/validators/companies_house_number_validator.rb
+++ b/lib/defra_ruby/validators/companies_house_number_validator.rb
@@ -25,14 +25,14 @@ module DefraRuby
       def value_is_present?(record, attribute, value)
         return true if value.present?
 
-        record.errors[attribute] << error_message(:blank)
+        add_validation_error(record, attribute, :blank)
         false
       end
 
       def format_is_valid?(record, attribute, value)
         return true if value.match?(VALID_COMPANIES_HOUSE_REGISTRATION_NUMBER_REGEX)
 
-        record.errors[attribute] << error_message(:invalid_format)
+        add_validation_error(record, attribute, :invalid_format)
         false
       end
 
@@ -41,12 +41,12 @@ module DefraRuby
         when :active
           true
         when :inactive
-          record.errors[attribute] << error_message(:inactive)
+          add_validation_error(record, attribute, :inactive)
         when :not_found
-          record.errors[attribute] << error_message(:not_found)
+          add_validation_error(record, attribute, :not_found)
         end
       rescue StandardError
-        record.errors[attribute] << error_message(:error)
+        add_validation_error(record, attribute, :error)
       end
 
     end

--- a/lib/defra_ruby/validators/concerns/can_validate_characters.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_characters.rb
@@ -10,7 +10,7 @@ module DefraRuby
         # Name fields must contain only letters, spaces, commas, full stops, hyphens and apostrophes
         return true if value.match?(/\A[-a-z\s,.']+\z/i)
 
-        record.errors[attribute] << error_message(:invalid_format)
+        add_validation_error(record, attribute, :invalid_format)
         false
       end
 

--- a/lib/defra_ruby/validators/concerns/can_validate_length.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_length.rb
@@ -9,7 +9,7 @@ module DefraRuby
       def value_is_not_too_long?(record, attribute, value, max_length)
         return true if value.length <= max_length
 
-        record.errors[attribute] << error_message(:too_long)
+        add_validation_error(record, attribute, :too_long)
         false
       end
 

--- a/lib/defra_ruby/validators/concerns/can_validate_presence.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_presence.rb
@@ -9,7 +9,7 @@ module DefraRuby
       def value_is_present?(record, attribute, value)
         return true if value.present?
 
-        record.errors[attribute] << error_message(:blank)
+        add_validation_error(record, attribute, :blank)
         false
       end
 

--- a/lib/defra_ruby/validators/concerns/can_validate_selection.rb
+++ b/lib/defra_ruby/validators/concerns/can_validate_selection.rb
@@ -10,7 +10,7 @@ module DefraRuby
         # In this case, we do want `false.present?` to return `true` https://github.com/rails/rails/issues/10804
         return true if (value == false || value.present?) && valid_options.include?(value)
 
-        record.errors[attribute] << error_message(:inclusion)
+        add_validation_error(record, attribute, :inclusion)
         false
       end
 

--- a/lib/defra_ruby/validators/email_validator.rb
+++ b/lib/defra_ruby/validators/email_validator.rb
@@ -19,7 +19,7 @@ module DefraRuby
         # validate_email_format returns nil if the validation passes
         return true unless ValidatesEmailFormatOf.validate_email_format(value)
 
-        record.errors[attribute] << error_message(:invalid_format)
+        add_validation_error(record, attribute, :invalid_format)
         false
       end
 

--- a/lib/defra_ruby/validators/grid_reference_validator.rb
+++ b/lib/defra_ruby/validators/grid_reference_validator.rb
@@ -22,7 +22,7 @@ module DefraRuby
       def valid_format?(record, attribute, value)
         return true if value.match?(/\A#{grid_reference_pattern}\z/)
 
-        record.errors[attribute] << error_message(:invalid_format)
+        add_validation_error(record, attribute, :invalid_format)
         false
       end
 
@@ -30,7 +30,7 @@ module DefraRuby
         OsMapRef::Location.for(value).easting
         true
       rescue OsMapRef::Error
-        record.errors[attribute] << error_message(:invalid)
+        add_validation_error(record, attribute, :invalid)
         false
       end
 

--- a/lib/defra_ruby/validators/past_date_validator.rb
+++ b/lib/defra_ruby/validators/past_date_validator.rb
@@ -9,13 +9,13 @@ module DefraRuby
         date = value.to_date
 
         if date > Date.today
-          record.errors[attribute] << error_message(:past_date)
+          add_validation_error(record, attribute, :past_date)
 
           return false
         end
 
         if date.year < 1900
-          record.errors[attribute] << error_message(:invalid_date)
+          add_validation_error(record, attribute, :invalid_date)
 
           return false
         end

--- a/lib/defra_ruby/validators/phone_number_validator.rb
+++ b/lib/defra_ruby/validators/phone_number_validator.rb
@@ -23,7 +23,7 @@ module DefraRuby
         Phonelib.default_country = "GB"
         return true if Phonelib.valid?(value)
 
-        record.errors[attribute] << error_message(:invalid_format)
+        add_validation_error(record, attribute, :invalid_format)
         false
       end
 

--- a/lib/defra_ruby/validators/token_validator.rb
+++ b/lib/defra_ruby/validators/token_validator.rb
@@ -19,7 +19,7 @@ module DefraRuby
         # 24-character unique tokens
         return true if value.length == 24
 
-        record.errors[attribute] << error_message(:invalid_format)
+        add_validation_error(record, attribute, :invalid_format)
         false
       end
     end


### PR DESCRIPTION
This PR updates the way we add error messages to use a more modern syntax.

We don't believe this is currently causing any bugs, but see https://eaflood.atlassian.net/browse/RUBY-1138 for backstory.